### PR TITLE
Fix (un-)registering runner with similar names

### DIFF
--- a/manifests/runner.pp
+++ b/manifests/runner.pp
@@ -38,13 +38,13 @@ define gitlab_ci_runner::runner (
       # Execute gitlab ci multirunner unregister
       exec {"Unregister_runner_${title}":
         command => "/usr/bin/${binary} unregister -n ${title}",
-        onlyif  => "/bin/grep ${runner_name} ${toml_file}",
+        onlyif  => "/bin/grep \'\"${runner_name}\"\' ${toml_file}",
       }
     } else {
       # Execute gitlab ci multirunner register
       exec {"Register_runner_${title}":
         command => "/usr/bin/${binary} register -n ${parameters_string}",
-        unless  => "/bin/grep ${runner_name} ${toml_file}",
+        unless  => "/bin/grep \'\"${runner_name}\"\' ${toml_file}",
       }
     }
 


### PR DESCRIPTION
#### Pull Request (PR) description
I have registered a runner with name `behat-js` and now I want to register another runner with name `behat`. Due to the `runner_name` not being quoted in the unless/onlyif statements, the second runner will not be registered, because /bin/grep will find `behat-js` when looking for `behat`.

Fixed by quoting the `runner_name` in the unless/onlyif statements.