### PR TITLE
allow build_dir and cache_dir to be managed

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ gitlab_ci_runner::concurrent: 4
 
 gitlab_ci_runner::metrics_server: "localhost:8888"
 
+gitlab_ci_runner::manage_docker: true
+gitlab_ci_runner::manage_docker: true
+
 gitlab_ci_runner::runners:
   test_runner1:{}
   test_runner2:{}
@@ -41,6 +44,8 @@ gitlab_ci_runner::runner_defaults:
   registration-token: "1234567890abcdef"
   executor: "docker"
   docker-image: "ubuntu:trusty"
+  builds_dir: "/tmp"
+  cache_dir: "/tmp"
 ```
 
 To unregister a specific runner you may use `ensure` param:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,8 @@ class gitlab_ci_runner (
   Hash                       $runners,
   Hash                       $runner_defaults,
   Optional[Integer]          $concurrent               = undef,
+  Optional[String]           $builds_dir               = undef,
+  Optional[String]           $cache_dir                = undef,
   Optional[Pattern[/.*:.+/]] $metrics_server           = undef,
   Boolean                    $manage_docker            = true,
   Boolean                    $manage_repo              = true,
@@ -113,6 +115,24 @@ class gitlab_ci_runner (
       path    => '/etc/gitlab-runner/config.toml',
       line    => "metrics_server = \"${metrics_server}\"",
       match   => '^metrics_server = .+',
+      require => Package[$package_name],
+      notify  => Exec['gitlab-runner-restart'],
+    }
+  }
+  if $builds_dir {
+    file_line { 'gitlab-runner-builds_dir':
+      path    => '/etc/gitlab-runner/config.toml',
+      line    => "builds_dir = \"${builds_dir}\"",
+      match   => '^builds_dir = .+',
+      require => Package[$package_name],
+      notify  => Exec['gitlab-runner-restart'],
+    }
+  }
+  if $cache_dir {
+    file_line { 'gitlab-runner-cache_dir':
+      path    => '/etc/gitlab-runner/config.toml',
+      line    => "cache_dir = \"${cache_dir}\"",
+      match   => '^cache_dir = .+',
       require => Package[$package_name],
       notify  => Exec['gitlab-runner-restart'],
     }

--- a/manifests/runner.pp
+++ b/manifests/runner.pp
@@ -28,7 +28,8 @@ define gitlab_ci_runner::runner (
 
   # Convert configuration into a string
   $parameters_array = join_keys_to_values($_config, '=')
-  $parameters_array_dashes = prefix($parameters_array, '--')
+  $parameters_array_no_underscores = regsubst($parameters_array, '_', '-', 'G')
+  $parameters_array_dashes = prefix($parameters_array_no_underscores, '--')
   $parameters_string = join($parameters_array_dashes, ' ')
 
   $runner_name = $_config['name']

--- a/spec/classes/gitlab_ci_runner_spec.rb
+++ b/spec/classes/gitlab_ci_runner_spec.rb
@@ -33,6 +33,8 @@ describe 'gitlab_ci_runner', type: :class do
       it { is_expected.to contain_gitlab_ci_runner__runner('test_runner').that_requires('Exec[gitlab-runner-restart]') }
       it { is_expected.not_to contain_file_line('gitlab-runner-concurrent') }
       it { is_expected.not_to contain_file_line('gitlab-runner-metrics-server') }
+      it { is_expected.not_to contain_file_line('gitlab-runner-builds_dir') }
+      it { is_expected.not_to contain_file_line('gitlab-runner-cache_dir') }
 
       context 'with concurrent => 10' do
         let(:params) do
@@ -66,6 +68,40 @@ describe 'gitlab_ci_runner', type: :class do
           is_expected.to contain_file_line('gitlab-runner-metrics-server').with('path' => '/etc/gitlab-runner/config.toml',
                                                                                 'line'  => 'metrics_server = "localhost:9252"',
                                                                                 'match' => '^metrics_server = .+')
+        end
+      end
+      context 'with builds_dir => /tmp/builds_dir' do
+        let(:params) do
+          {
+            'runner_defaults' => {},
+            'runners' => {},
+            'builds_dir' => '/tmp/builds_dir'
+          }
+        end
+
+        it { is_expected.to contain_file_line('gitlab-runner-builds_dir').that_requires("Package[#{package_name}]") }
+        it { is_expected.to contain_file_line('gitlab-runner-builds_dir').that_notifies('Exec[gitlab-runner-restart]') }
+        it do
+          is_expected.to contain_file_line('gitlab-runner-builds_dir').with('path' => '/etc/gitlab-runner/config.toml',
+                                                                            'line'  => 'builds_dir = "/tmp/builds_dir"',
+                                                                            'match' => '^builds_dir = .+')
+        end
+      end
+      context 'with cache_dir => /tmp/cache_dir' do
+        let(:params) do
+          {
+            'runner_defaults' => {},
+            'runners' => {},
+            'cache_dir' => '/tmp/cache_dir'
+          }
+        end
+
+        it { is_expected.to contain_file_line('gitlab-runner-cache_dir').that_requires("Package[#{package_name}]") }
+        it { is_expected.to contain_file_line('gitlab-runner-cache_dir').that_notifies('Exec[gitlab-runner-restart]') }
+        it do
+          is_expected.to contain_file_line('gitlab-runner-cache_dir').with('path' => '/etc/gitlab-runner/config.toml',
+                                                                           'line'  => 'cache_dir = "/tmp/cache_dir"',
+                                                                           'match' => '^cache_dir = .+')
         end
       end
     end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that there is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    This merge allows the module to manage build_dir and cache_dir
    The tests have been updated to reflect the expectations of the module following the exist structure
    The README.md has been updated with examples of managing these new settings
    The README.md also includes examples for managing existing variables (manage_docker, manage_repo along with the modules defaults)
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Fixes #33
-->
