### PR TITLE
Allow ensure => "present" for runners

### DIFF
--- a/manifests/runner.pp
+++ b/manifests/runner.pp
@@ -23,8 +23,12 @@ define gitlab_ci_runner::runner (
   $_default_config = merge($default_config, $name_config)
   $config = $runners_hash[$title]
 
+  # Pull out ensure key, which shouldn't be passed to command
+  $ensure = $config['ensure']
+  $config_without_ensure = delete($config, 'ensure')
+
   # Merge default config with actual config
-  $_config = merge($_default_config, $config)
+  $_config = merge($_default_config, $config_without_ensure)
 
   # Convert configuration into a string
   $parameters_array = join_keys_to_values($_config, '=')
@@ -35,7 +39,7 @@ define gitlab_ci_runner::runner (
   $runner_name = $_config['name']
   $toml_file = '/etc/gitlab-runner/config.toml'
 
-  if $_config['ensure'] == 'absent' {
+  if $ensure == 'absent' {
       # Execute gitlab ci multirunner unregister
       exec {"Unregister_runner_${title}":
         command => "/usr/bin/${binary} unregister -n ${title}",

--- a/spec/classes/gitlab_ci_runner_spec.rb
+++ b/spec/classes/gitlab_ci_runner_spec.rb
@@ -104,6 +104,35 @@ describe 'gitlab_ci_runner', type: :class do
                                                                            'match' => '^cache_dir = .+')
         end
       end
+      context 'with ensure => present' do
+        let(:params) do
+          super().merge(
+            'runners' => {
+              'test_runner' => {
+                'ensure' => 'present'
+              }
+            }
+          )
+        end
+
+        it { is_expected.to contain_exec('Register_runner_test_runner').with('command' => %r{/usr/bin/[^ ]+ register }) }
+        it { is_expected.not_to contain_exec('Register_runner_test_runner').with('command' => %r{--ensure=}) }
+      end
+
+      context 'with ensure => absent' do
+        let(:params) do
+          super().merge(
+            'runners' => {
+              'test_runner' => {
+                'ensure' => 'absent'
+              }
+            }
+          )
+        end
+
+        it { is_expected.to contain_exec('Unregister_runner_test_runner').with('command' => %r{/usr/bin/[^ ]+ unregister }) }
+        it { is_expected.not_to contain_exec('Unregister_runner_test_runner').with('command' => %r{--ensure=}) }
+      end
     end
   end
 end


### PR DESCRIPTION
The runner config hash currently accepts "absent" for the ensure key, but not "present". This isn't a huge problem since omitting the ensure key has the same effect, but it's natural to support both.

I noticed this when flipping that setting in a config file that ends up being passed through to this module, at which point we hit errors since the `gitlab-runner register` command is then called with `--ensure=present` (which isn't a real flag).