### PR TITLE
Fix xz dependency on RedHat systems

### DIFF
--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -1,0 +1,2 @@
+---
+gitlab_ci_runner::xz_package_name: 'xz-utils'

--- a/data/family/RedHat.yaml
+++ b/data/family/RedHat.yaml
@@ -1,0 +1,2 @@
+---
+gitlab_ci_runner::xz_package_name: 'xz'

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,16 @@
+---
+version: 5
+
+defaults:
+  datadir: 'data'
+  data_hash: yaml_data
+
+hierarchy:
+  - name: 'OS Major Release Overrides'
+    path: "family/%{facts.os.family}/%{facts.os.release.major}.yaml"
+  - name: 'Operating System'
+    path: "os/%{facts.os.name}.yaml"
+  - name: 'Operating System Family'
+    path: "family/%{facts.os.family}.yaml"
+  - name: 'Defaults'
+    path: 'defaults.yaml'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,13 +17,13 @@
 class gitlab_ci_runner (
   Hash                       $runners,
   Hash                       $runner_defaults,
+  String                     $xz_package_name,
   Optional[Integer]          $concurrent               = undef,
   Optional[String]           $builds_dir               = undef,
   Optional[String]           $cache_dir                = undef,
   Optional[Pattern[/.*:.+/]] $metrics_server           = undef,
   Boolean                    $manage_docker            = true,
   Boolean                    $manage_repo              = true,
-  String                     $xz_package_name          = 'xz-utils',
   String                     $package_ensure           = installed,
   String                     $package_name             = 'gitlab-runner',
 ){


### PR DESCRIPTION
#### Pull Request (PR) description

On RedHat and CentOS, xz utilities are part of the `xz` package, not `xz-utils`.

#### This Pull Request (PR) fixes the following issues

Fixes #25
