### PR TITLE
rename metrics_server to listen_address

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -113,12 +113,12 @@ class gitlab_ci_runner (
 
   if $listen_address {
     file_line { 'gitlab-runner-listen-address':
-      path              => '/etc/gitlab-runner/config.toml',
-      after             => '^concurrent',
-      line              => "listen_address = \"${listen_address}\"",
-      match             => '^listen_address = .+',
-      require           => Package[$package_name],
-      notify            => Exec['gitlab-runner-restart'],
+      path    => '/etc/gitlab-runner/config.toml',
+      after   => '^concurrent',
+      line    => "listen_address = \"${listen_address}\"",
+      match   => '^listen_address = .+',
+      require => Package[$package_name],
+      notify  => Exec['gitlab-runner-restart'],
     }
   }
   if $builds_dir {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -92,7 +92,7 @@ class gitlab_ci_runner (
         }
       }
       default: {
-        fail("gitlab_ci_runner::manage_repo parameter for ${osfamily} is not supported.")
+        fail("gitlab_ci_runner::manage_repo parameter for $osfamily is not supported.")
       }
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -92,7 +92,7 @@ class gitlab_ci_runner (
         }
       }
       default: {
-        fail("gitlab_ci_runner::manage_repo parameter for $osfamily is not supported.")
+        fail("gitlab_ci_runner::manage_repo parameter for $::osfamily is not supported.")
       }
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -92,7 +92,7 @@ class gitlab_ci_runner (
         }
       }
       default: {
-        fail("gitlab_ci_runner::manage_repo parameter for $::osfamily is not supported.")
+        fail("gitlab_ci_runner::manage_repo parameter for ${::osfamily} is not supported.")
       }
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -92,7 +92,7 @@ class gitlab_ci_runner (
         }
       }
       default: {
-        fail("gitlab_ci_runner::manage_repo parameter for ${::osfamily} is not supported.")
+        fail("gitlab_ci_runner::manage_repo parameter for ${osfamily} is not supported.")
       }
     }
   }

--- a/spec/classes/gitlab_ci_runner_spec.rb
+++ b/spec/classes/gitlab_ci_runner_spec.rb
@@ -65,7 +65,8 @@ describe 'gitlab_ci_runner', type: :class do
         it { is_expected.to contain_file_line('gitlab-runner-listen-address').that_requires("Package[#{package_name}]") }
         it { is_expected.to contain_file_line('gitlab-runner-listen-address').that_notifies('Exec[gitlab-runner-restart]') }
         it do
-          is_expected.to contain_file_line('gitlab-runner-listen-address').with('path' => '/etc/gitlab-runner/config.toml',
+          is_expected.to contain_file_line('gitlab-runner-listen-address').with('path'  => '/etc/gitlab-runner/config.toml',
+                                                                                'after' => 'concurrent = 10',
                                                                                 'line'  => 'listen-address = "localhost:9252"',
                                                                                 'match' => '^listen-address = .+')
         end

--- a/spec/classes/gitlab_ci_runner_spec.rb
+++ b/spec/classes/gitlab_ci_runner_spec.rb
@@ -64,8 +64,6 @@ describe 'gitlab_ci_runner', type: :class do
 
         it { is_expected.to contain_file_line('gitlab-runner-listen-address').that_requires("Package[#{package_name}]") }
         it { is_expected.to contain_file_line('gitlab-runner-listen-address').that_notifies('Exec[gitlab-runner-restart]') }
-
-
         it do
           is_expected.to contain_file_line('gitlab-runner-listen-address').with('path' => '/etc/gitlab-runner/config.toml',
                                                                                 'line' => 'listen_address = "localhost:9252"',

--- a/spec/classes/gitlab_ci_runner_spec.rb
+++ b/spec/classes/gitlab_ci_runner_spec.rb
@@ -21,20 +21,20 @@ describe 'gitlab_ci_runner', type: :class do
         }
       end
 
-      it {is_expected.to compile.with_all_deps}
+      it { is_expected.to compile.with_all_deps }
 
-      it {is_expected.to contain_class('docker::images')}
-      it {is_expected.to contain_package('gitlab-runner')}
-      it {is_expected.to contain_exec('gitlab-runner-restart').that_requires("Package[#{package_name}]")}
+      it { is_expected.to contain_class('docker::images') }
+      it { is_expected.to contain_package('gitlab-runner') }
+      it { is_expected.to contain_exec('gitlab-runner-restart').that_requires("Package[#{package_name}]") }
       it do
         is_expected.to contain_exec('gitlab-runner-restart').with('command' => "/usr/bin/#{package_name} restart",
                                                                   'refreshonly' => true)
       end
-      it {is_expected.to contain_gitlab_ci_runner__runner('test_runner').that_requires('Exec[gitlab-runner-restart]')}
-      it {is_expected.not_to contain_file_line('gitlab-runner-concurrent')}
-      it {is_expected.not_to contain_file_line('gitlab-runner-listen-address')}
-      it {is_expected.not_to contain_file_line('gitlab-runner-builds_dir')}
-      it {is_expected.not_to contain_file_line('gitlab-runner-cache_dir')}
+      it { is_expected.to contain_gitlab_ci_runner__runner('test_runner').that_requires('Exec[gitlab-runner-restart]') }
+      it { is_expected.not_to contain_file_line('gitlab-runner-concurrent') }
+      it { is_expected.not_to contain_file_line('gitlab-runner-listen-address') }
+      it { is_expected.not_to contain_file_line('gitlab-runner-builds_dir') }
+      it { is_expected.not_to contain_file_line('gitlab-runner-cache_dir') }
 
       context 'with concurrent => 10' do
         let(:params) do
@@ -45,8 +45,8 @@ describe 'gitlab_ci_runner', type: :class do
           }
         end
 
-        it {is_expected.to contain_file_line('gitlab-runner-concurrent').that_requires("Package[#{package_name}]")}
-        it {is_expected.to contain_file_line('gitlab-runner-concurrent').that_notifies('Exec[gitlab-runner-restart]')}
+        it { is_expected.to contain_file_line('gitlab-runner-concurrent').that_requires("Package[#{package_name}]") }
+        it { is_expected.to contain_file_line('gitlab-runner-concurrent').that_notifies('Exec[gitlab-runner-restart]') }
         it do
           is_expected.to contain_file_line('gitlab-runner-concurrent').with('path' => '/etc/gitlab-runner/config.toml',
                                                                             'line' => 'concurrent = 10',
@@ -62,8 +62,8 @@ describe 'gitlab_ci_runner', type: :class do
           }
         end
 
-        it {is_expected.to contain_file_line('gitlab-runner-listen-address').that_requires("Package[#{package_name}]")}
-        it {is_expected.to contain_file_line('gitlab-runner-listen-address').that_notifies('Exec[gitlab-runner-restart]')}
+        it { is_expected.to contain_file_line('gitlab-runner-listen-address').that_requires("Package[#{package_name}]") }
+        it { is_expected.to contain_file_line('gitlab-runner-listen-address').that_notifies('Exec[gitlab-runner-restart]') }
 
 
         it do
@@ -81,8 +81,8 @@ describe 'gitlab_ci_runner', type: :class do
           }
         end
 
-        it {is_expected.to contain_file_line('gitlab-runner-builds_dir').that_requires("Package[#{package_name}]")}
-        it {is_expected.to contain_file_line('gitlab-runner-builds_dir').that_notifies('Exec[gitlab-runner-restart]')}
+        it { is_expected.to contain_file_line('gitlab-runner-builds_dir').that_requires("Package[#{package_name}]") }
+        it { is_expected.to contain_file_line('gitlab-runner-builds_dir').that_notifies('Exec[gitlab-runner-restart]') }
         it do
           is_expected.to contain_file_line('gitlab-runner-builds_dir').with('path' => '/etc/gitlab-runner/config.toml',
                                                                             'line' => 'builds_dir = "/tmp/builds_dir"',
@@ -98,8 +98,8 @@ describe 'gitlab_ci_runner', type: :class do
           }
         end
 
-        it {is_expected.to contain_file_line('gitlab-runner-cache_dir').that_requires("Package[#{package_name}]")}
-        it {is_expected.to contain_file_line('gitlab-runner-cache_dir').that_notifies('Exec[gitlab-runner-restart]')}
+        it { is_expected.to contain_file_line('gitlab-runner-cache_dir').that_requires("Package[#{package_name}]") }
+        it { is_expected.to contain_file_line('gitlab-runner-cache_dir').that_notifies('Exec[gitlab-runner-restart]') }
         it do
           is_expected.to contain_file_line('gitlab-runner-cache_dir').with('path' => '/etc/gitlab-runner/config.toml',
                                                                            'line' => 'cache_dir = "/tmp/cache_dir"',
@@ -115,8 +115,8 @@ describe 'gitlab_ci_runner', type: :class do
           }
         end
 
-        it {is_expected.to contain_file_line('gitlab-runner-sentry_dsn').that_requires("Package[#{package_name}]")}
-        it {is_expected.to contain_file_line('gitlab-runner-sentry_dsn').that_notifies('Exec[gitlab-runner-restart]')}
+        it { is_expected.to contain_file_line('gitlab-runner-sentry_dsn').that_requires("Package[#{package_name}]") }
+        it { is_expected.to contain_file_line('gitlab-runner-sentry_dsn').that_notifies('Exec[gitlab-runner-restart]') }
         it do
           is_expected.to contain_file_line('gitlab-runner-sentry_dsn').with('path' => '/etc/gitlab-runner/config.toml',
                                                                             'line' => 'sentry_dsn = "https://123abc@localhost/1"',
@@ -134,8 +134,8 @@ describe 'gitlab_ci_runner', type: :class do
           )
         end
 
-        it {is_expected.to contain_exec('Register_runner_test_runner').with('command' => %r{/usr/bin/[^ ]+ register })}
-        it {is_expected.not_to contain_exec('Register_runner_test_runner').with('command' => %r{--ensure=})}
+        it { is_expected.to contain_exec('Register_runner_test_runner').with('command' => %r{/usr/bin/[^ ]+ register }) }
+        it { is_expected.not_to contain_exec('Register_runner_test_runner').with('command' => %r{--ensure=}) }
       end
 
       context 'with ensure => absent' do
@@ -149,8 +149,8 @@ describe 'gitlab_ci_runner', type: :class do
           )
         end
 
-        it {is_expected.to contain_exec('Unregister_runner_test_runner').with('command' => %r{/usr/bin/[^ ]+ unregister })}
-        it {is_expected.not_to contain_exec('Unregister_runner_test_runner').with('command' => %r{--ensure=})}
+        it { is_expected.to contain_exec('Unregister_runner_test_runner').with('command' => %r{/usr/bin/[^ ]+ unregister }) }
+        it { is_expected.not_to contain_exec('Unregister_runner_test_runner').with('command' => %r{--ensure=}) }
       end
     end
   end

--- a/spec/classes/gitlab_ci_runner_spec.rb
+++ b/spec/classes/gitlab_ci_runner_spec.rb
@@ -32,7 +32,7 @@ describe 'gitlab_ci_runner', type: :class do
       end
       it { is_expected.to contain_gitlab_ci_runner__runner('test_runner').that_requires('Exec[gitlab-runner-restart]') }
       it { is_expected.not_to contain_file_line('gitlab-runner-concurrent') }
-      it { is_expected.not_to contain_file_line('gitlab-runner-metrics-server') }
+      it { is_expected.not_to contain_file_line('gitlab-runner-listen-address') }
       it { is_expected.not_to contain_file_line('gitlab-runner-builds_dir') }
       it { is_expected.not_to contain_file_line('gitlab-runner-cache_dir') }
 
@@ -53,21 +53,21 @@ describe 'gitlab_ci_runner', type: :class do
                                                                             'match' => '^concurrent = \d+')
         end
       end
-      context 'with metrics_server => localhost:9252' do
+      context 'with listen-address => localhost:9252' do
         let(:params) do
           {
             'runner_defaults' => {},
             'runners' => {},
-            'metrics_server' => 'localhost:9252'
+            'listen-address' => 'localhost:9252'
           }
         end
 
-        it { is_expected.to contain_file_line('gitlab-runner-metrics-server').that_requires("Package[#{package_name}]") }
-        it { is_expected.to contain_file_line('gitlab-runner-metrics-server').that_notifies('Exec[gitlab-runner-restart]') }
+        it { is_expected.to contain_file_line('gitlab-runner-listen-address').that_requires("Package[#{package_name}]") }
+        it { is_expected.to contain_file_line('gitlab-runner-listen-address').that_notifies('Exec[gitlab-runner-restart]') }
         it do
-          is_expected.to contain_file_line('gitlab-runner-metrics-server').with('path' => '/etc/gitlab-runner/config.toml',
-                                                                                'line'  => 'metrics_server = "localhost:9252"',
-                                                                                'match' => '^metrics_server = .+')
+          is_expected.to contain_file_line('gitlab-runner-listen-address').with('path' => '/etc/gitlab-runner/config.toml',
+                                                                                'line'  => 'listen-address = "localhost:9252"',
+                                                                                'match' => '^listen-address = .+')
         end
       end
       context 'with builds_dir => /tmp/builds_dir' do

--- a/spec/classes/gitlab_ci_runner_spec.rb
+++ b/spec/classes/gitlab_ci_runner_spec.rb
@@ -21,20 +21,20 @@ describe 'gitlab_ci_runner', type: :class do
         }
       end
 
-      it { is_expected.to compile.with_all_deps }
+      it {is_expected.to compile.with_all_deps}
 
-      it { is_expected.to contain_class('docker::images') }
-      it { is_expected.to contain_package('gitlab-runner') }
-      it { is_expected.to contain_exec('gitlab-runner-restart').that_requires("Package[#{package_name}]") }
+      it {is_expected.to contain_class('docker::images')}
+      it {is_expected.to contain_package('gitlab-runner')}
+      it {is_expected.to contain_exec('gitlab-runner-restart').that_requires("Package[#{package_name}]")}
       it do
         is_expected.to contain_exec('gitlab-runner-restart').with('command' => "/usr/bin/#{package_name} restart",
                                                                   'refreshonly' => true)
       end
-      it { is_expected.to contain_gitlab_ci_runner__runner('test_runner').that_requires('Exec[gitlab-runner-restart]') }
-      it { is_expected.not_to contain_file_line('gitlab-runner-concurrent') }
-      it { is_expected.not_to contain_file_line('gitlab-runner-listen-address') }
-      it { is_expected.not_to contain_file_line('gitlab-runner-builds_dir') }
-      it { is_expected.not_to contain_file_line('gitlab-runner-cache_dir') }
+      it {is_expected.to contain_gitlab_ci_runner__runner('test_runner').that_requires('Exec[gitlab-runner-restart]')}
+      it {is_expected.not_to contain_file_line('gitlab-runner-concurrent')}
+      it {is_expected.not_to contain_file_line('gitlab-runner-listen-address')}
+      it {is_expected.not_to contain_file_line('gitlab-runner-builds_dir')}
+      it {is_expected.not_to contain_file_line('gitlab-runner-cache_dir')}
 
       context 'with concurrent => 10' do
         let(:params) do
@@ -45,11 +45,11 @@ describe 'gitlab_ci_runner', type: :class do
           }
         end
 
-        it { is_expected.to contain_file_line('gitlab-runner-concurrent').that_requires("Package[#{package_name}]") }
-        it { is_expected.to contain_file_line('gitlab-runner-concurrent').that_notifies('Exec[gitlab-runner-restart]') }
+        it {is_expected.to contain_file_line('gitlab-runner-concurrent').that_requires("Package[#{package_name}]")}
+        it {is_expected.to contain_file_line('gitlab-runner-concurrent').that_notifies('Exec[gitlab-runner-restart]')}
         it do
           is_expected.to contain_file_line('gitlab-runner-concurrent').with('path' => '/etc/gitlab-runner/config.toml',
-                                                                            'line'  => 'concurrent = 10',
+                                                                            'line' => 'concurrent = 10',
                                                                             'match' => '^concurrent = \d+')
         end
       end
@@ -58,17 +58,18 @@ describe 'gitlab_ci_runner', type: :class do
           {
             'runner_defaults' => {},
             'runners' => {},
-            'listen-address' => 'localhost:9252'
+            'listen_address' => 'localhost:9252'
           }
         end
 
-        it { is_expected.to contain_file_line('gitlab-runner-listen-address').that_requires("Package[#{package_name}]") }
-        it { is_expected.to contain_file_line('gitlab-runner-listen-address').that_notifies('Exec[gitlab-runner-restart]') }
+        it {is_expected.to contain_file_line('gitlab-runner-listen-address').that_requires("Package[#{package_name}]")}
+        it {is_expected.to contain_file_line('gitlab-runner-listen-address').that_notifies('Exec[gitlab-runner-restart]')}
+
+
         it do
-          is_expected.to contain_file_line('gitlab-runner-listen-address').with('path'  => '/etc/gitlab-runner/config.toml',
-                                                                                'after' => 'concurrent = 10',
-                                                                                'line'  => 'listen-address = "localhost:9252"',
-                                                                                'match' => '^listen-address = .+')
+          is_expected.to contain_file_line('gitlab-runner-listen-address').with('path' => '/etc/gitlab-runner/config.toml',
+                                                                                'line' => 'listen_address = "localhost:9252"',
+                                                                                'match' => '^listen_address = .+')
         end
       end
       context 'with builds_dir => /tmp/builds_dir' do
@@ -80,11 +81,11 @@ describe 'gitlab_ci_runner', type: :class do
           }
         end
 
-        it { is_expected.to contain_file_line('gitlab-runner-builds_dir').that_requires("Package[#{package_name}]") }
-        it { is_expected.to contain_file_line('gitlab-runner-builds_dir').that_notifies('Exec[gitlab-runner-restart]') }
+        it {is_expected.to contain_file_line('gitlab-runner-builds_dir').that_requires("Package[#{package_name}]")}
+        it {is_expected.to contain_file_line('gitlab-runner-builds_dir').that_notifies('Exec[gitlab-runner-restart]')}
         it do
           is_expected.to contain_file_line('gitlab-runner-builds_dir').with('path' => '/etc/gitlab-runner/config.toml',
-                                                                            'line'  => 'builds_dir = "/tmp/builds_dir"',
+                                                                            'line' => 'builds_dir = "/tmp/builds_dir"',
                                                                             'match' => '^builds_dir = .+')
         end
       end
@@ -97,11 +98,11 @@ describe 'gitlab_ci_runner', type: :class do
           }
         end
 
-        it { is_expected.to contain_file_line('gitlab-runner-cache_dir').that_requires("Package[#{package_name}]") }
-        it { is_expected.to contain_file_line('gitlab-runner-cache_dir').that_notifies('Exec[gitlab-runner-restart]') }
+        it {is_expected.to contain_file_line('gitlab-runner-cache_dir').that_requires("Package[#{package_name}]")}
+        it {is_expected.to contain_file_line('gitlab-runner-cache_dir').that_notifies('Exec[gitlab-runner-restart]')}
         it do
           is_expected.to contain_file_line('gitlab-runner-cache_dir').with('path' => '/etc/gitlab-runner/config.toml',
-                                                                           'line'  => 'cache_dir = "/tmp/cache_dir"',
+                                                                           'line' => 'cache_dir = "/tmp/cache_dir"',
                                                                            'match' => '^cache_dir = .+')
         end
       end
@@ -114,11 +115,11 @@ describe 'gitlab_ci_runner', type: :class do
           }
         end
 
-        it { is_expected.to contain_file_line('gitlab-runner-sentry_dsn').that_requires("Package[#{package_name}]") }
-        it { is_expected.to contain_file_line('gitlab-runner-sentry_dsn').that_notifies('Exec[gitlab-runner-restart]') }
+        it {is_expected.to contain_file_line('gitlab-runner-sentry_dsn').that_requires("Package[#{package_name}]")}
+        it {is_expected.to contain_file_line('gitlab-runner-sentry_dsn').that_notifies('Exec[gitlab-runner-restart]')}
         it do
           is_expected.to contain_file_line('gitlab-runner-sentry_dsn').with('path' => '/etc/gitlab-runner/config.toml',
-                                                                            'line'  => 'sentry_dsn = "https://123abc@localhost/1"',
+                                                                            'line' => 'sentry_dsn = "https://123abc@localhost/1"',
                                                                             'match' => '^sentry_dsn = .+')
         end
       end
@@ -133,8 +134,8 @@ describe 'gitlab_ci_runner', type: :class do
           )
         end
 
-        it { is_expected.to contain_exec('Register_runner_test_runner').with('command' => %r{/usr/bin/[^ ]+ register }) }
-        it { is_expected.not_to contain_exec('Register_runner_test_runner').with('command' => %r{--ensure=}) }
+        it {is_expected.to contain_exec('Register_runner_test_runner').with('command' => %r{/usr/bin/[^ ]+ register })}
+        it {is_expected.not_to contain_exec('Register_runner_test_runner').with('command' => %r{--ensure=})}
       end
 
       context 'with ensure => absent' do
@@ -148,8 +149,8 @@ describe 'gitlab_ci_runner', type: :class do
           )
         end
 
-        it { is_expected.to contain_exec('Unregister_runner_test_runner').with('command' => %r{/usr/bin/[^ ]+ unregister }) }
-        it { is_expected.not_to contain_exec('Unregister_runner_test_runner').with('command' => %r{--ensure=}) }
+        it {is_expected.to contain_exec('Unregister_runner_test_runner').with('command' => %r{/usr/bin/[^ ]+ unregister })}
+        it {is_expected.not_to contain_exec('Unregister_runner_test_runner').with('command' => %r{--ensure=})}
       end
     end
   end


### PR DESCRIPTION
According to official documentation - https://docs.gitlab.com/runner/monitoring/README.html#configuration-of-the-metrics-http-server

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
