### PR TITLE
Add custom keyserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ gitlab_ci_runner::runner_defaults:
 To unregister a specific runner you may use `ensure` param:
 
 ```yaml
-gitlab_ci_runner::gitlab_ci_runners:
+gitlab_ci_runner::runners:
   test_runner1:{}
   test_runner2:{}
   test_runner3:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,20 @@
 ## This module installs and configures Gitlab CI Runners.
 #
 # === Parameters
+# [*runners*]
+#   Type: Hash
+#   Default: unset
+#   Hashkeys are used as $title in runners.pp. The subkeys have to be named as the parameter names from
+#   ´gitlab-runner register´ command cause they're later joined to one entire string using 2 hyphen to
+#   look like shell command parameters.
+#   See ´https://docs.gitlab.com/runner/register/#one-line-registration-command´ for details.
+#
+#   example:
+#     $example_runner = {
+#       registration-token => 'gitlab-token',
+#       url                => 'https://gitlab.com/',
+#       tag-list           => "docker,aws",
+#     },
 #
 # [*concurrent*]
 #   Default: `undef`
@@ -27,6 +41,8 @@ class gitlab_ci_runner (
   Boolean                    $manage_repo              = true,
   String                     $package_ensure           = installed,
   String                     $package_name             = 'gitlab-runner',
+  String                     $repo_base_url            = 'https://packages.gitlab.com',
+  String                     $repo_keyserver           = 'keys.gnupg.net',
 ){
   if $manage_docker {
     # workaround for cirunner issue #1617
@@ -35,7 +51,7 @@ class gitlab_ci_runner (
 
     $docker_images = {
       ubuntu_trusty => {
-        image => 'ubuntu',
+        image     => 'ubuntu',
         image_tag => 'trusty',
       },
     }
@@ -45,8 +61,6 @@ class gitlab_ci_runner (
   }
 
   if $manage_repo {
-    $repo_base_url = 'https://packages.gitlab.com'
-
     case $::osfamily {
       'Debian': {
 
@@ -56,7 +70,7 @@ class gitlab_ci_runner (
           repos    => 'main',
           key      => {
             'id'     => '1A4C919DB987D435939638B914219A96E15E78F4',
-            'server' => 'keys.gnupg.net',
+            'server' => $repo_keyserver,
           },
           include  => {
             'src' => false,
@@ -100,6 +114,10 @@ class gitlab_ci_runner (
   package { $package_name:
     ensure => $package_ensure,
   }
+  service { $package_name:
+    ensure => running,
+    enable => true,
+  }
 
   if $concurrent != undef {
     file_line { 'gitlab-runner-concurrent':
@@ -107,7 +125,7 @@ class gitlab_ci_runner (
       line    => "concurrent = ${concurrent}",
       match   => '^concurrent = \d+',
       require => Package[$package_name],
-      notify  => Exec['gitlab-runner-restart'],
+      notify  => Service[$package_name],
     }
   }
 
@@ -117,7 +135,7 @@ class gitlab_ci_runner (
       line    => "metrics_server = \"${metrics_server}\"",
       match   => '^metrics_server = .+',
       require => Package[$package_name],
-      notify  => Exec['gitlab-runner-restart'],
+      notify  => Service[$package_name],
     }
   }
   if $builds_dir {
@@ -126,7 +144,7 @@ class gitlab_ci_runner (
       line    => "builds_dir = \"${builds_dir}\"",
       match   => '^builds_dir = .+',
       require => Package[$package_name],
-      notify  => Exec['gitlab-runner-restart'],
+      notify  => Service[$package_name],
     }
   }
   if $cache_dir {
@@ -135,7 +153,7 @@ class gitlab_ci_runner (
       line    => "cache_dir = \"${cache_dir}\"",
       match   => '^cache_dir = .+',
       require => Package[$package_name],
-      notify  => Exec['gitlab-runner-restart'],
+      notify  => Service[$package_name],
     }
   }
   if $sentry_dsn {
@@ -159,6 +177,6 @@ class gitlab_ci_runner (
     binary         => $package_name,
     default_config => $runner_defaults,
     runners_hash   => $runners,
-    require        => Exec['gitlab-runner-restart'],
+    notify         => Exec['gitlab-runner-restart'],
   }
 }

--- a/manifests/runner.pp
+++ b/manifests/runner.pp
@@ -16,9 +16,10 @@ define gitlab_ci_runner::runner (
   Hash $runners_hash,
   Hash $default_config = {},
 ) {
-  # Set resource name as name for the runner
+  # Set resource name as name for the runner and replace under_scores for later use
+  $title_no_underscore = regsubst($title, '_', '-', 'G')
   $name_config = {
-    name => $title,
+    name => $title_no_underscore,
   }
   $_default_config = merge($default_config, $name_config)
   $config = $runners_hash[$title]

--- a/manifests/runner.pp
+++ b/manifests/runner.pp
@@ -43,13 +43,13 @@ define gitlab_ci_runner::runner (
       # Execute gitlab ci multirunner unregister
       exec {"Unregister_runner_${title}":
         command => "/usr/bin/${binary} unregister -n ${title}",
-        onlyif  => "/bin/grep \'\"${runner_name}\"\' ${toml_file}",
+        onlyif  => "/bin/grep \'${runner_name}\' ${toml_file}",
       }
     } else {
       # Execute gitlab ci multirunner register
       exec {"Register_runner_${title}":
         command => "/usr/bin/${binary} register -n ${parameters_string}",
-        unless  => "/bin/grep \'\"${runner_name}\"\' ${toml_file}",
+        unless  => "/bin/grep \'${runner_name}\' ${toml_file}",
       }
     }
 

--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,14 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.13.0 < 6.0.0"
+    },
+    {
+      "name": "puppetlabs/apt",
+      "version_requirement": ">= 6.3.0 < 7.0.0"
+    },
+    {
+      "name": "puppetlabs-docker",
+      "version_requirement": ">= 3.1.0 < 3.5.0"
     }
   ],
   "operatingsystem_support": [
@@ -22,6 +30,12 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "14.04"
+      ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "9"
       ]
     }
   ],

--- a/spec/classes/gitlab_ci_runner_spec.rb
+++ b/spec/classes/gitlab_ci_runner_spec.rb
@@ -5,12 +5,10 @@ describe 'gitlab_ci_runner', type: :class do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) do
-       # Workaround a puppet-spec issue Debian 9
-       # https://github.com/rodjek/rspec-puppet/issues/629
+        # Workaround a puppet-spec issue Debian 9
+        # https://github.com/rodjek/rspec-puppet/issues/629
         facts.merge(
-          {
-            operatingsystemmajrelease: '9',
-          }
+          operatingsystemmajrelease: '9'
         )
       end
       let(:params) do
@@ -37,7 +35,7 @@ describe 'gitlab_ci_runner', type: :class do
         is_expected.to contain_exec('gitlab-runner-restart').with('command' => "/usr/bin/#{package_name} restart",
                                                                   'refreshonly' => true)
       end
-      it { is_expected.to contain_gitlab_ci_runner__runner('test_runner').that_notifies("Exec[gitlab-runner-restart]") }
+      it { is_expected.to contain_gitlab_ci_runner__runner('test_runner').that_notifies('Exec[gitlab-runner-restart]') }
       it { is_expected.not_to contain_file_line('gitlab-runner-concurrent') }
       it { is_expected.not_to contain_file_line('gitlab-runner-metrics-server') }
       it { is_expected.not_to contain_file_line('gitlab-runner-builds_dir') }

--- a/spec/classes/gitlab_ci_runner_spec.rb
+++ b/spec/classes/gitlab_ci_runner_spec.rb
@@ -5,7 +5,13 @@ describe 'gitlab_ci_runner', type: :class do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) do
-        facts
+       # Workaround a puppet-spec issue Debian 9
+       # https://github.com/rodjek/rspec-puppet/issues/629
+        facts.merge(
+          {
+            operatingsystemmajrelease: '9',
+          }
+        )
       end
       let(:params) do
         {
@@ -25,12 +31,13 @@ describe 'gitlab_ci_runner', type: :class do
 
       it { is_expected.to contain_class('docker::images') }
       it { is_expected.to contain_package('gitlab-runner') }
+      it { is_expected.to contain_service('gitlab-runner') }
       it { is_expected.to contain_exec('gitlab-runner-restart').that_requires("Package[#{package_name}]") }
       it do
         is_expected.to contain_exec('gitlab-runner-restart').with('command' => "/usr/bin/#{package_name} restart",
                                                                   'refreshonly' => true)
       end
-      it { is_expected.to contain_gitlab_ci_runner__runner('test_runner').that_requires('Exec[gitlab-runner-restart]') }
+      it { is_expected.to contain_gitlab_ci_runner__runner('test_runner').that_notifies("Exec[gitlab-runner-restart]") }
       it { is_expected.not_to contain_file_line('gitlab-runner-concurrent') }
       it { is_expected.not_to contain_file_line('gitlab-runner-metrics-server') }
       it { is_expected.not_to contain_file_line('gitlab-runner-builds_dir') }
@@ -46,7 +53,7 @@ describe 'gitlab_ci_runner', type: :class do
         end
 
         it { is_expected.to contain_file_line('gitlab-runner-concurrent').that_requires("Package[#{package_name}]") }
-        it { is_expected.to contain_file_line('gitlab-runner-concurrent').that_notifies('Exec[gitlab-runner-restart]') }
+        it { is_expected.to contain_file_line('gitlab-runner-concurrent').that_notifies("Service[#{package_name}]") }
         it do
           is_expected.to contain_file_line('gitlab-runner-concurrent').with('path' => '/etc/gitlab-runner/config.toml',
                                                                             'line'  => 'concurrent = 10',
@@ -63,7 +70,7 @@ describe 'gitlab_ci_runner', type: :class do
         end
 
         it { is_expected.to contain_file_line('gitlab-runner-metrics-server').that_requires("Package[#{package_name}]") }
-        it { is_expected.to contain_file_line('gitlab-runner-metrics-server').that_notifies('Exec[gitlab-runner-restart]') }
+        it { is_expected.to contain_file_line('gitlab-runner-metrics-server').that_notifies("Service[#{package_name}]") }
         it do
           is_expected.to contain_file_line('gitlab-runner-metrics-server').with('path' => '/etc/gitlab-runner/config.toml',
                                                                                 'line'  => 'metrics_server = "localhost:9252"',
@@ -80,7 +87,7 @@ describe 'gitlab_ci_runner', type: :class do
         end
 
         it { is_expected.to contain_file_line('gitlab-runner-builds_dir').that_requires("Package[#{package_name}]") }
-        it { is_expected.to contain_file_line('gitlab-runner-builds_dir').that_notifies('Exec[gitlab-runner-restart]') }
+        it { is_expected.to contain_file_line('gitlab-runner-builds_dir').that_notifies("Service[#{package_name}]") }
         it do
           is_expected.to contain_file_line('gitlab-runner-builds_dir').with('path' => '/etc/gitlab-runner/config.toml',
                                                                             'line'  => 'builds_dir = "/tmp/builds_dir"',
@@ -97,7 +104,7 @@ describe 'gitlab_ci_runner', type: :class do
         end
 
         it { is_expected.to contain_file_line('gitlab-runner-cache_dir').that_requires("Package[#{package_name}]") }
-        it { is_expected.to contain_file_line('gitlab-runner-cache_dir').that_notifies('Exec[gitlab-runner-restart]') }
+        it { is_expected.to contain_file_line('gitlab-runner-cache_dir').that_notifies("Service[#{package_name}]") }
         it do
           is_expected.to contain_file_line('gitlab-runner-cache_dir').with('path' => '/etc/gitlab-runner/config.toml',
                                                                            'line'  => 'cache_dir = "/tmp/cache_dir"',


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

This PR will add the possibility to set a custom gitlab-runner repository. It's useful if you have a local mirror and don't have direct internet access on the node you want to install it. 
Additionally it will add a service resource to let systemd manage it.
Also it will fix a small issue with the name pattern in runner.pp .

Bye,
Johannes