### PR TITLE
Add custom repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ gitlab_ci_runner::runner_defaults:
 To unregister a specific runner you may use `ensure` param:
 
 ```yaml
-gitlab_ci_runner::gitlab_ci_runners:
+gitlab_ci_runner::runners:
   test_runner1:{}
   test_runner2:{}
   test_runner3:
@@ -62,4 +62,4 @@ gitlab_ci_runner::gitlab_ci_runners:
 
 ## Limitations
 
-The Gitlab CI runner installation is at the moment only tested on Ubuntu 14.04.
+The Gitlab CI runner installation is at the moment only tested on Ubuntu 14.04 and Debian 9.

--- a/manifests/runner.pp
+++ b/manifests/runner.pp
@@ -16,9 +16,10 @@ define gitlab_ci_runner::runner (
   Hash $runners_hash,
   Hash $default_config = {},
 ) {
-  # Set resource name as name for the runner
+  # Set resource name as name for the runner and replace under_scores for later use
+  $title_no_underscore = regsubst($title, '_', '-', 'G')
   $name_config = {
-    name => $title,
+    name => $title_no_underscore,
   }
   $_default_config = merge($default_config, $name_config)
   $config = $runners_hash[$title]

--- a/manifests/runner.pp
+++ b/manifests/runner.pp
@@ -43,13 +43,13 @@ define gitlab_ci_runner::runner (
       # Execute gitlab ci multirunner unregister
       exec {"Unregister_runner_${title}":
         command => "/usr/bin/${binary} unregister -n ${title}",
-        onlyif  => "/bin/grep \'\"${runner_name}\"\' ${toml_file}",
+        onlyif  => "/bin/grep \'${runner_name}\' ${toml_file}",
       }
     } else {
       # Execute gitlab ci multirunner register
       exec {"Register_runner_${title}":
         command => "/usr/bin/${binary} register -n ${parameters_string}",
-        unless  => "/bin/grep \'\"${runner_name}\"\' ${toml_file}",
+        unless  => "/bin/grep \'${runner_name}\' ${toml_file}",
       }
     }
 

--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.13.0 < 6.0.0"
+    },
+    {
+      "name": "puppetlabs/apt",
+      "version_requirement": ">= 6.3.0 < 8.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -22,6 +26,12 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "14.04"
+      ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "9"
       ]
     }
   ],


### PR DESCRIPTION
Hi!

This PR will add the possibility to set a custom gitlab-runner repository. It's useful if you have a local mirror and don't have direct internet access on the node you want to install it.
Additionally it will add a service resource to let systemd manage it.
Also it will fix a small issue with the name pattern in runner.pp .

Bye,
Johannes