### PR TITLE
Fix runner name in unregister command

### DIFF
--- a/manifests/runner.pp
+++ b/manifests/runner.pp
@@ -43,7 +43,7 @@ define gitlab_ci_runner::runner (
   if $ensure == 'absent' {
       # Execute gitlab ci multirunner unregister
       exec {"Unregister_runner_${title}":
-        command => "/usr/bin/${binary} unregister -n ${title}",
+        command => "/usr/bin/${binary} unregister -n ${runner_name}",
         onlyif  => "/bin/grep \'${runner_name}\' ${toml_file}",
       }
     } else {


### PR DESCRIPTION
#### Pull Request (PR) description

This PR aims to fix unregistering runners with names where `$title` contains underscores, since this module replaces all underscores with hyphens.

Additional info:

- The `name` parameter inside `/etc/gitlab-runner/config.toml` is set to `$_config['name']` via registration:
  https://github.com/voxpupuli/puppet-gitlab_ci_runner/blob/99d621ea6f2f69a8707da988870a28a2f14862ba/manifests/runner.pp#L52
- `$runner_name` is assigned to `$_config['name']`:
  https://github.com/voxpupuli/puppet-gitlab_ci_runner/blob/99d621ea6f2f69a8707da988870a28a2f14862ba/manifests/runner.pp#L40
- Searching the configuration file is done with `grep $runner_name`:
  https://github.com/voxpupuli/puppet-gitlab_ci_runner/blob/99d621ea6f2f69a8707da988870a28a2f14862ba/manifests/runner.pp#L47

#### This Pull Request (PR) fixes the following issues

Similar but not #45