### PR TITLE
Add listen_address parameter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -83,7 +83,15 @@ Default value: `undef`
 
 Data type: `Optional[Pattern[/.*:.+/]]`
 
-[host]:<port> to enable metrics server as described in https://docs.gitlab.com/runner/monitoring/README.html#configuration-of-the-metrics-http-server
+(Deprecated) [host]:<port> to enable metrics server as described in https://docs.gitlab.com/runner/monitoring/README.html#configuration-of-the-metrics-http-server.
+
+Default value: `undef`
+
+##### `listen_address`
+
+Data type: `Optional[Pattern[/.*:.+/]]`
+
+Address (<host>:<port>) on which the Prometheus metrics HTTP server should be listening.
 
 Default value: `undef`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,7 +24,9 @@
 # @param cache_dir
 #   Absolute path to a directory where build caches will be stored in context of selected executor (locally, Docker, SSH). If the docker executor is used, this directory needs to be included in its volumes parameter.
 # @param metrics_server
-#   [host]:<port> to enable metrics server as described in https://docs.gitlab.com/runner/monitoring/README.html#configuration-of-the-metrics-http-server
+#   (Deprecated) [host]:<port> to enable metrics server as described in https://docs.gitlab.com/runner/monitoring/README.html#configuration-of-the-metrics-http-server.
+# @param listen_address
+#   Address (<host>:<port>) on which the Prometheus metrics HTTP server should be listening.
 # @param sentry_dsn
 #   Enable tracking of all system level errors to sentry.
 # @param manage_docker
@@ -50,6 +52,7 @@ class gitlab_ci_runner (
   Optional[String]           $builds_dir               = undef,
   Optional[String]           $cache_dir                = undef,
   Optional[Pattern[/.*:.+/]] $metrics_server           = undef,
+  Optional[Pattern[/.*:.+/]] $listen_address           = undef,
   Optional[String]           $sentry_dsn               = undef,
   Boolean                    $manage_docker            = true,
   Boolean                    $manage_repo              = true,
@@ -155,6 +158,15 @@ class gitlab_ci_runner (
       path    => $config_path,
       line    => "metrics_server = \"${metrics_server}\"",
       match   => '^metrics_server = .+',
+      require => Package[$package_name],
+      notify  => Service[$package_name],
+    }
+  }
+  if $listen_address {
+    file_line { 'gitlab-runner-listen-address':
+      path    => $config_path,
+      line    => "listen_address = \"${listen_address}\"",
+      match   => '^listen_address = .+',
       require => Package[$package_name],
       notify  => Service[$package_name],
     }

--- a/spec/classes/gitlab_ci_runner_spec.rb
+++ b/spec/classes/gitlab_ci_runner_spec.rb
@@ -78,6 +78,26 @@ describe 'gitlab_ci_runner', type: :class do
                                                                                 'match' => '^metrics_server = .+')
         end
       end
+      context 'with listen_address => localhost:9252' do
+        let(:params) do
+          {
+            'runner_defaults' => {},
+            'runners' => {},
+            'listen_address' => 'localhost:9252'
+          }
+        end
+
+        it do
+          is_expected.to contain_file_line('gitlab-runner-listen-address').
+            with(
+              path: '/etc/gitlab-runner/config.toml',
+              line: 'listen_address = "localhost:9252"',
+              match: '^listen_address = .+'
+            ).
+            that_requires("Package[#{package_name}]").
+            that_notifies("Service[#{package_name}]")
+        end
+      end
       context 'with builds_dir => /tmp/builds_dir' do
         let(:params) do
           {


### PR DESCRIPTION
# This MR depends on #64

#### Pull Request (PR) description
#46 seems to be stable. This just adds the `listen_address` parameter without removing the `metrics_server` parameter.

#### This Pull Request (PR) fixes the following issues
Closes #46.