### PR TITLE
Add Amazon Linux support (RedHat OS Family)

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -27,9 +27,22 @@ class gitlab_ci_runner::repo (
       Exec['apt_update'] -> Package[$package_name]
     }
     'RedHat': {
+      if $facts['os']['name'] == 'Amazon' {
+        if $facts['os']['release']['major'] == '2' { # Amazon Linux 2 is based off of CentOS 7
+          $base_url = "${repo_base_url}/runner/${package_name}/el/7/\$basearch"
+          $source_base_url = "${repo_base_url}/runner/${package_name}/el/7/SRPMS"
+        } else { # Amazon Linux 1 is based off of CentOS 6 but os.release.major will differ
+          $base_url = "${repo_base_url}/runner/${package_name}/el/6/\$basearch"
+          $source_base_url = "${repo_base_url}/runner/${package_name}/el/6/SRPMS"
+        }
+      } else {
+        $base_url = "${repo_base_url}/runner/${package_name}/el/\$releasever/\$basearch"
+        $source_base_url = "${repo_base_url}/runner/${package_name}/el/\$releasever/SRPMS"
+      }
+
       yumrepo { "runner_${package_name}":
         ensure        => 'present',
-        baseurl       => "${repo_base_url}/runner/${package_name}/el/\$releasever/\$basearch",
+        baseurl       => $base_url,
         descr         => "runner_${package_name}",
         enabled       => '1',
         gpgcheck      => '0',
@@ -41,7 +54,7 @@ class gitlab_ci_runner::repo (
 
       yumrepo { "runner_${package_name}-source":
         ensure        => 'present',
-        baseurl       => "${repo_base_url}/runner/${package_name}/el/\$releasever/SRPMS",
+        baseurl       => $source_base_url,
         descr         => "runner_${package_name}-source",
         enabled       => '1',
         gpgcheck      => '0',

--- a/metadata.json
+++ b/metadata.json
@@ -23,6 +23,13 @@
   ],
   "operatingsystem_support": [
     {
+      "operatingsystem": "Amazon",
+      "operatingsystemrelease": [
+        "1",
+        "2"
+      ]
+    },
+    {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6",

--- a/spec/classes/gitlab_ci_runner_spec.rb
+++ b/spec/classes/gitlab_ci_runner_spec.rb
@@ -197,11 +197,21 @@ describe 'gitlab_ci_runner', type: :class do
               )
           end
         when 'RedHat'
+          os_release_version = if facts[:os]['name'] == 'Amazon'
+                                 if facts[:os]['release']['major'] == 2
+                                   '7'
+                                 else
+                                   '6'
+                                 end
+                               else
+                                 '$releasever'
+                               end
+
           it do
             is_expected.to contain_yumrepo('runner_gitlab-runner').
               with(
                 ensure: 'present',
-                baseurl: "https://packages.gitlab.com/runner/gitlab-runner/el/\$releasever/\$basearch",
+                baseurl: "https://packages.gitlab.com/runner/gitlab-runner/el/#{os_release_version}/\$basearch",
                 descr: 'runner_gitlab-runner',
                 enabled: '1',
                 gpgcheck: '0',
@@ -216,7 +226,7 @@ describe 'gitlab_ci_runner', type: :class do
             is_expected.to contain_yumrepo('runner_gitlab-runner-source').
               with(
                 ensure: 'present',
-                baseurl: "https://packages.gitlab.com/runner/gitlab-runner/el/\$releasever/SRPMS",
+                baseurl: "https://packages.gitlab.com/runner/gitlab-runner/el/#{os_release_version}/SRPMS",
                 descr: 'runner_gitlab-runner-source',
                 enabled: '1',
                 gpgcheck: '0',


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This PR adds support for Amazon Linux 1 and 2 which is part of the RedHat OS family. Below is the output of facter os. Amazon Linux 1 is based off of EL6 and Amazon Linux 2 is based off of EL7. This module hardcodes the $releasever for amazon linux instances.

```
facter os
{
  architecture => "x86_64",
  family => "RedHat",
  hardware => "x86_64",
  name => "Amazon",
  release => {
    full => "2",
    major => "2"
  },
  selinux => {
    enabled => false
  }
}
```
