### PR TITLE
Add bolt task to register/unregister a runner

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,5 +1,9 @@
 ---
 .travis.yml:
+  before_install:
+    - yes | gem update --system
+    - bundle --version
+    - git clone https://github.com/puppetlabs/puppetlabs-ruby_task_helper ../ruby_task_helper
   docker_sets:
     - set: debian8-64
     - set: debian9-64
@@ -9,3 +13,7 @@
     - set: centos7-64
   secure: "uwKQeb0ngonWkgYCFTgrzALAOhjlTBXmJMTdB37z/E9cdFRqwDJy6aUpgXTMCareaiEUaKnkPW0+nNRZZl+ewA7JOb1oBqx2rYNf1URX+eRQLT5yZjD+9h2r1pSNId3ku45q4WhtWRsZ/foD3iPM+S
 2g2BI28Ui4/AZYvz//YBa9uWpxVb1pqr2x6aAWxfh3pIGAiok8YnsYZ3qoW0MheGAcL4ReLsdQD9+eSUHYx+eA0zHvMbBVpdTnwFbEgD0WLV5bhaNShHBYWLrOKrYZFsd+XZjOyC8jDiYReeo219KHjDd5RZL38FC8Mtg+oHjUKUvvq2GEKDpPGq1BJ3opBChYbPfRx4KVQpYBeYap9PtkE2s9rSbvsARYVELl9nVoW0j2+nZYhL94efXieEiX/Qt/rwyR9YFvuRO71hzA4nIIaC11pz+kLm1uzJsLgd5tVAlUQjhjvUecRdL98XoI0WTGm3l4sT/ptqfdRvP4XJj0jN4twEQ6FKKUAQ0oaPOZwM2HF4YRN9PtijqU1VoZsUEpYtJECGQjrWEADpYD4qpRxpgGw/4/k/McRFegLC1oCSNqB2uiZIqyTmcr9X5ycNkG0yis4Koq+Chc4CXgZTOAwa2AgzUI8qPdBTI/1G1CBSiGta1X5MKHQM2yEgj2G0jnDAFhi5Im1ylYjBb5O+k="
+Gemfile:
+  optional:
+    ':test':
+      - gem: 'webmock'

--- a/.sync.yml
+++ b/.sync.yml
@@ -4,6 +4,7 @@
     - yes | gem update --system
     - bundle --version
     - git clone https://github.com/puppetlabs/puppetlabs-ruby_task_helper ../ruby_task_helper
+    - scripts/start-gitlab.sh
   docker_sets:
     - set: debian8-64
     - set: debian9-64

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
   - yes | gem update --system
   - bundle --version
   - git clone https://github.com/puppetlabs/puppetlabs-ruby_task_helper ../ruby_task_helper
+  - scripts/start-gitlab.sh
 script:
   - 'bundle exec rake $CHECK'
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache: bundler
 before_install:
   - yes | gem update --system
   - bundle --version
+  - git clone https://github.com/puppetlabs/puppetlabs-ruby_task_helper ../ruby_task_helper
 script:
   - 'bundle exec rake $CHECK'
 matrix:

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :test do
   gem 'coveralls',                                                  :require => false
   gem 'simplecov-console',                                          :require => false
   gem 'parallel_tests',                                             :require => false
+  gem 'webmock',                                                    :require => false
 end
 
 group :development do

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -20,6 +20,11 @@ _Private Classes_
 
 * [`gitlab_ci_runner::runner`](#gitlab_ci_runnerrunner): This module installs and configures Gitlab CI Runners.
 
+**Tasks**
+
+* [`register_runner`](#register_runner): Registers a runner on a Gitlab instance.
+* [`unregister_runner`](#unregister_runner): Unregisters a runner from a Gitlab instance.
+
 ## Classes
 
 ### gitlab_ci_runner
@@ -197,4 +202,94 @@ Data type: `Hash`
 Hash with default configration for runners. This will be merged with the runners_hash config.
 
 Default value: {}
+
+## Tasks
+
+### register_runner
+
+Registers a runner on a Gitlab instance.
+
+**Supports noop?** false
+
+#### Parameters
+
+##### `url`
+
+Data type: `String[1]`
+
+The url to your Gitlab instance. Please only provide the host part (e.g https://gitlab.com)
+
+##### `token`
+
+Data type: `String[1]`
+
+Registration token.
+
+##### `description`
+
+Data type: `Optional[String[1]]`
+
+Runners description.
+
+##### `info`
+
+Data type: `Optional[Hash]`
+
+Runners metadata.
+
+##### `active`
+
+Data type: `Optional[Boolean]`
+
+Whether the Runner is active.
+
+##### `locked`
+
+Data type: `Optional[Boolean]`
+
+Whether the Runner should be locked for current project.
+
+##### `run_untagged`
+
+Data type: `Optional[Boolean]`
+
+Whether the Runner should handle untagged jobs.
+
+##### `tag_list`
+
+Data type: `Optional[Array[String[1]]]`
+
+List of Runners tags.
+
+##### `access_level`
+
+Data type: `Optional[Enum['not_protected', 'ref_protected']]`
+
+The access_level of the runner.
+
+##### `maximum_timeout`
+
+Data type: `Optional[Integer[1]]`
+
+Maximum timeout set when this Runner will handle the job.
+
+### unregister_runner
+
+Unregisters a runner from a Gitlab instance.
+
+**Supports noop?** false
+
+#### Parameters
+
+##### `url`
+
+Data type: `String[1]`
+
+The url to your Gitlab instance. Please provide the host part only! (e.g https://gitlab.com)
+
+##### `token`
+
+Data type: `String[1]`
+
+Runners authentication token.
 

--- a/scripts/start-gitlab.sh
+++ b/scripts/start-gitlab.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+if [[ "${CHECK}" != "beaker" ]]; then
+  echo "Only starting Gitlab test container for beaker tests"
+  exit 0
+fi
+
+docker run --detach --rm \
+  --name gitlab \
+  --hostname gitlab \
+  -e GITLAB_ROOT_PASSWORD=voxpupulirocks \
+  --publish 80:80 \
+  gitlab/gitlab-ce
+
+IP="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' gitlab)"
+echo "${IP}" > ~/GITLAB_IP
+
+until wget -t 1 "http://${IP}:80" -O /dev/null -q; do
+  docker logs gitlab --tail 10
+  sleep 3
+done
+
+OUTPUT="$(echo 'puts "INSTANCE TOKEN: #{Gitlab::CurrentSettings.current_application_settings.runners_registration_token}"' | docker exec -i gitlab gitlab-rails console)"
+INSTANCE_TOKEN="$(echo "$OUTPUT" | awk '/^INSTANCE TOKEN:/ {print $NF}')"
+echo "${INSTANCE_TOKEN}" > ~/INSTANCE_TOKEN

--- a/spec/acceptance/bolt_tasks_spec.rb
+++ b/spec/acceptance/bolt_tasks_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper_acceptance'
+require 'json'
+
+describe 'Gitlab Runner bolt tasks' do
+  let(:registrationtoken) do
+    File.read(File.expand_path('~/INSTANCE_TOKEN')).chomp
+  end
+
+  describe 'register_runner' do
+    context 'registers a runner' do
+      let(:result) do
+        result = shell("bolt task run gitlab_ci_runner::register_runner --format json --targets localhost url=http://gitlab token=#{registrationtoken}").stdout.chomp
+        JSON.parse(result)['items'][0]['result']
+      end
+
+      it 'returns a valid token' do
+        expect(result['token']).to be_instance_of(String)
+      end
+
+      it 'returns  a runner id' do
+        expect(result['id']).to be_instance_of(Integer)
+      end
+    end
+
+    context 'returns error on failure' do
+      let(:result) do
+        result = shell('bolt task run gitlab_ci_runner::register_runner --format json --targets localhost url=http://gitlab token=wrong-token', acceptable_exit_codes: [0, 2]).stdout.chomp
+        JSON.parse(result)['items'][0]['result']
+      end
+
+      it 'returns the correct exception' do
+        expect(result['_error']['kind']).to eq('bolt-plugin/gitlab-ci-runner-register-error')
+      end
+    end
+  end
+
+  describe 'unregister_runner' do
+    context 'unregisters a runner' do
+      let(:authtoken) do
+        result = shell("bolt task run gitlab_ci_runner::register_runner --format json --targets localhost url=http://gitlab token=#{registrationtoken}").stdout.chomp
+        JSON.parse(result)['items'][0]['result']['token']
+      end
+      let(:result) do
+        result = shell("bolt task run gitlab_ci_runner::unregister_runner --format json --targets localhost url=http://gitlab token=#{authtoken}").stdout.chomp
+        JSON.parse(result)['items'][0]['result']
+      end
+
+      it 'succeeds' do
+        expect(result['status']).to eq('success')
+      end
+    end
+
+    context 'returns error on failure' do
+      let(:result) do
+        result = shell('bolt task run gitlab_ci_runner::unregister_runner --format json --targets localhost url=http://gitlab token=wrong-token', acceptable_exit_codes: [0, 2]).stdout.chomp
+        JSON.parse(result)['items'][0]['result']
+      end
+
+      it 'returns the correct exception' do
+        expect(result['_error']['kind']).to eq('bolt-plugin/gitlab-ci-runner-unregister-error')
+      end
+    end
+  end
+end

--- a/spec/tasks/register_runner_spec.rb
+++ b/spec/tasks/register_runner_spec.rb
@@ -1,0 +1,28 @@
+require 'webmock/rspec'
+require_relative '../../tasks/register_runner.rb'
+
+describe RegisterRunnerTask do
+  let(:params) do
+    {
+      url: 'https://gitlab.example.org',
+      token: 'abcdef1234'
+    }
+  end
+  let(:task) { described_class.new }
+
+  describe 'task' do
+    it 'can register a runner' do
+      stub_request(:post, 'https://gitlab.example.org/api/v4/runners').
+        with(body: { token: 'abcdef1234' }).
+        to_return(body: '{"id": 777, "token": "3bz5wqfDiYBhxoUNuGVu"}')
+      expect(task.task(params)).to eq('id' => 777, 'token' => '3bz5wqfDiYBhxoUNuGVu')
+    end
+
+    it 'can raise an error' do
+      params.merge(token: 'invalid-token')
+      stub_request(:post, 'https://gitlab.example.org/api/v4/runners').
+        to_return(status: [403, 'Forbidden'])
+      expect { task.task(params) }.to raise_error(TaskHelper::Error, %r{Gitlab runner failed to register: Forbidden})
+    end
+  end
+end

--- a/spec/tasks/unregister_runner_spec.rb
+++ b/spec/tasks/unregister_runner_spec.rb
@@ -1,0 +1,28 @@
+require 'webmock/rspec'
+require_relative '../../tasks/unregister_runner.rb'
+
+describe UnregisterRunnerTask do
+  let(:params) do
+    {
+      url: 'https://gitlab.example.org',
+      token: 'abcdef1234'
+    }
+  end
+  let(:task) { described_class.new }
+
+  describe 'task' do
+    it 'can unregister a runner' do
+      stub_request(:delete, 'https://gitlab.example.org/api/v4/runners').
+        with(body: { token: 'abcdef1234' }).
+        to_return(body: nil)
+      expect(task.task(params)).to eq(status: 'success')
+    end
+
+    it 'can raise an error' do
+      params.merge(token: 'invalid-token')
+      stub_request(:delete, 'https://gitlab.example.org/api/v4/runners').
+        to_return(status: [403, 'Forbidden'])
+      expect { task.task(params) }.to raise_error(TaskHelper::Error, %r{Gitlab runner failed to unregister: Forbidden})
+    end
+  end
+end

--- a/tasks/register_runner.json
+++ b/tasks/register_runner.json
@@ -1,0 +1,47 @@
+{
+  "description": "Registers a runner on a Gitlab instance.",
+  "files": ["ruby_task_helper/files/task_helper.rb"],
+  "input_method": "stdin",
+  "parameters": {
+    "url": {
+      "description": "The url to your Gitlab instance. Please only provide the host part (e.g https://gitlab.com)",
+      "type": "String[1]"
+    },
+    "token": {
+      "description": "Registration token.",
+      "type": "String[1]"
+    },
+    "description": {
+      "description": "Runners description.",
+      "type": "Optional[String[1]]"
+    },
+    "info": {
+      "description": "Runners metadata.",
+      "type": "Optional[Hash]"
+    },
+    "active": {
+      "description": "Whether the Runner is active.",
+      "type": "Optional[Boolean]"
+    },
+    "locked": {
+      "description": "Whether the Runner should be locked for current project.",
+      "type": "Optional[Boolean]"
+    },
+    "run_untagged": {
+      "description": "Whether the Runner should handle untagged jobs.",
+      "type": "Optional[Boolean]"
+    },
+    "tag_list": {
+      "description": "List of Runners tags.",
+      "type": "Optional[Array[String[1]]]"
+    },
+    "access_level": {
+      "description": "The access_level of the runner.",
+      "type": "Optional[Enum['not_protected', 'ref_protected']]"
+    },
+    "maximum_timeout": {
+      "description": "Maximum timeout set when this Runner will handle the job.",
+      "type": "Optional[Integer[1]]"
+    }
+  }
+}

--- a/tasks/register_runner.rb
+++ b/tasks/register_runner.rb
@@ -1,0 +1,33 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+# frozen_string_literal: true
+
+require 'json'
+require 'net/http'
+require 'uri'
+require_relative '../../ruby_task_helper/files/task_helper.rb'
+
+class RegisterRunnerTask < TaskHelper
+  def task(**kwargs)
+    host    = kwargs[:url]
+    options = kwargs.reject { |key, _| %i[_task _installdir url].include?(key) }
+    uri     = URI.parse("#{host}/api/v4/runners")
+    headers = {
+      'Accept'       => 'application/json',
+      'Content-Type' => 'application/json'
+    }
+
+    http         = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https')
+    request      = Net::HTTP::Post.new(uri.request_uri, headers)
+    request.body = options.to_json
+    response     = http.request(request)
+
+    if response.is_a?(Net::HTTPSuccess)
+      JSON.parse(response.body)
+    else
+      msg = "Gitlab runner failed to register: #{response.message}"
+      raise TaskHelper::Error.new(msg, 'bolt-plugin/gitlab-ci-runner-register-error')
+    end
+  end
+end
+
+RegisterRunnerTask.run if $PROGRAM_NAME == __FILE__

--- a/tasks/unregister_runner.json
+++ b/tasks/unregister_runner.json
@@ -1,0 +1,15 @@
+{
+  "description": "Unregisters a runner from a Gitlab instance.",
+  "files": ["ruby_task_helper/files/task_helper.rb"],
+  "input_method": "stdin",
+  "parameters": {
+    "url": {
+      "description": "The url to your Gitlab instance. Please provide the host part only! (e.g https://gitlab.com)",
+      "type": "String[1]"
+    },
+    "token": {
+      "description": "Runners authentication token.",
+      "type": "String[1]"
+    }
+  }
+}

--- a/tasks/unregister_runner.rb
+++ b/tasks/unregister_runner.rb
@@ -1,0 +1,35 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+# frozen_string_literal: true
+
+require 'json'
+require 'net/http'
+require 'uri'
+require_relative '../../ruby_task_helper/files/task_helper.rb'
+
+class UnregisterRunnerTask < TaskHelper
+  def task(**kwargs)
+    host    = kwargs[:url]
+    options = kwargs.reject { |key, _| %i[_task _installdir url].include?(key) }
+    uri     = URI.parse("#{host}/api/v4/runners")
+    headers = {
+      'Accept'       => 'application/json',
+      'Content-Type' => 'application/json'
+    }
+
+    http         = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https')
+    request      = Net::HTTP::Delete.new(uri.request_uri, headers)
+    request.body = options.to_json
+    response     = http.request(request)
+
+    if response.is_a?(Net::HTTPSuccess)
+      {
+        status: 'success'
+      }
+    else
+      msg = "Gitlab runner failed to unregister: #{response.message}"
+      raise TaskHelper::Error.new(msg, 'bolt-plugin/gitlab-ci-runner-unregister-error')
+    end
+  end
+end
+
+UnregisterRunnerTask.run if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds Bolt tasks for (un)registering a Gitlab runner on a Gitlab instance.

To be able to modify the `before_install` in .travis.yml I've opened https://github.com/voxpupuli/modulesync_config/pull/631 to make this functionality available in modulesync.

#### This Pull Request (PR) relates to the following issues
#18
