### PR TITLE
Completely refactor gitlab_ci_runner::runner

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -52,11 +52,15 @@ Data type: `Hash`
 
 Hashkeys are used as $title in runners.pp. The subkeys have to be named as the parameter names from ´gitlab-runner register´ command cause they're later joined to one entire string using 2 hyphen to look like shell command parameters. See ´https://docs.gitlab.com/runner/register/#one-line-registration-command´ for details.
 
+Default value: {}
+
 ##### `runner_defaults`
 
 Data type: `Hash`
 
 A hash with defaults which will be later merged with $runners.
+
+Default value: {}
 
 ##### `xz_package_name`
 
@@ -174,27 +178,52 @@ Default value: '/etc/gitlab-runner/config.toml'
 
 This module installs and configures Gitlab CI Runners.
 
+#### Examples
+
+##### Simple runner registration
+
+```puppet
+gitlab_ci_runner::runner { example_runner:
+  config => {
+    'registration-token' => 'gitlab-token',
+    'url'                => 'https://gitlab.com',
+    'tag-list'           => 'docker,aws',
+  },
+}
+```
+
 #### Parameters
 
 The following parameters are available in the `gitlab_ci_runner::runner` defined type.
 
+##### `config`
+
+Data type: `Hash`
+
+Hash with configuration options.
+See https://docs.gitlab.com/runner/configuration/advanced-configuration.html for all possible options.
+
+##### `ensure`
+
+Data type: `Enum['present', 'absent']`
+
+If the runner should be 'present' or 'absent'. Will register/unregister the runner from Gitlab.
+
+Default value: 'present'
+
+##### `runner_name`
+
+Data type: `String[1]`
+
+The name of the runner.
+
+Default value: $title
+
 ##### `binary`
 
-Data type: `String`
+Data type: `String[1]`
 
 The name of the Gitlab runner binary.
 
-##### `runners_hash`
-
-Data type: `Hash`
-
-Hash with configuration for runners.
-
-##### `default_config`
-
-Data type: `Hash`
-
-Hash with default configration for runners. This will be merged with the runners_hash config.
-
-Default value: {}
+Default value: 'gitlab-runner'
 

--- a/manifests/runner.pp
+++ b/manifests/runner.pp
@@ -1,53 +1,65 @@
 # @summary This module installs and configures Gitlab CI Runners.
 #
+# @example Simple runner registration
+#   gitlab_ci_runner::runner { example_runner:
+#     config => {
+#       'registration-token' => 'gitlab-token',
+#       'url'                => 'https://gitlab.com',
+#       'tag-list'           => 'docker,aws',
+#     },
+#   }
+#
+# @param config
+#   Hash with configuration options.
+#   See https://docs.gitlab.com/runner/configuration/advanced-configuration.html for all possible options.
+# @param ensure
+#   If the runner should be 'present' or 'absent'. Will register/unregister the runner from Gitlab.
+# @param runner_name
+#   The name of the runner.
 # @param binary
 #   The name of the Gitlab runner binary.
-# @param runners_hash
-#   Hash with configuration for runners.
-# @param default_config
-#   Hash with default configration for runners. This will be merged with the runners_hash config.
 #
 define gitlab_ci_runner::runner (
-  String $binary,
-  Hash $runners_hash,
-  Hash $default_config = {},
+  Hash                      $config,
+  Enum['present', 'absent'] $ensure      = 'present',
+  String[1]                 $runner_name = $title,
+  String[1]                 $binary      = 'gitlab-runner',
 ) {
   # Set resource name as name for the runner and replace under_scores for later use
-  $title_no_underscore = regsubst($title, '_', '-', 'G')
-  $name_config = {
-    name => $title_no_underscore,
-  }
-  $_default_config = merge($default_config, $name_config)
-  $config = $runners_hash[$title]
+  $_name = regsubst($runner_name, '_', '-', 'G')
 
-  # Pull out ensure key, which shouldn't be passed to command
-  $ensure = $config['ensure']
-  $config_without_ensure = delete($config, 'ensure')
+  # To be able to use all parameters as command line arguments,
+  # we have to transform the configuration into something the gitlab-runner
+  # binary accepts:
+  # * Always prefix the options with '--'
+  # * Always join option names and values with '='
+  #
+  # In the end, flatten thewhole array and join all elements with a space as delimiter
+  $__config = $config.map |$item| {
+    # Ensure all keys use '-' instead of '_'. Needed for e.g. build_dir.
+    $key = regsubst($item[0], '_', '-', 'G')
 
-  # Merge default config with actual config
-  $_config = merge($_default_config, $config_without_ensure)
-
-  # Convert configuration into a string
-  $parameters_array = join_keys_to_values($_config, '=')
-  $parameters_array_no_underscores = regsubst($parameters_array, '_', '-', 'G')
-  $parameters_array_dashes = prefix($parameters_array_no_underscores, '--')
-  $parameters_string = join($parameters_array_dashes, ' ')
-
-  $runner_name = $_config['name']
-  $toml_file = '/etc/gitlab-runner/config.toml'
-
-  if $ensure == 'absent' {
-      # Execute gitlab ci multirunner unregister
-      exec {"Unregister_runner_${title}":
-        command => "/usr/bin/${binary} unregister -n ${runner_name}",
-        onlyif  => "/bin/grep \'${runner_name}\' ${toml_file}",
+    # If the value ($item[1]) is an Array multiple elements are added for each item
+    if $item[1] =~ Array {
+      $item[1].map |$nested| {
+        "--${key}=${nested}"
       }
     } else {
-      # Execute gitlab ci multirunner register
-      exec {"Register_runner_${title}":
-        command => "/usr/bin/${binary} register -n ${parameters_string}",
-        unless  => "/bin/grep -F \'${runner_name}\' ${toml_file}",
-      }
+      "--${key}=${item[1]}"
     }
+  }.flatten.join(' ')
 
+  if $ensure == 'absent' {
+    # Execute gitlab ci multirunner unregister
+    exec {"Unregister_runner_${title}":
+      command => "/usr/bin/${binary} unregister -n ${_name}",
+      onlyif  => "/bin/grep \'${_name}\' /etc/gitlab-runner/config.toml",
+    }
+  } else {
+    # Execute gitlab ci multirunner register
+    exec {"Register_runner_${title}":
+      command => "/usr/bin/${binary} register -n ${__config}",
+      unless  => "/bin/grep -F \'${_name}\' /etc/gitlab-runner/config.toml",
+    }
+  }
 }

--- a/spec/defines/runner_spec.rb
+++ b/spec/defines/runner_spec.rb
@@ -1,0 +1,109 @@
+require 'spec_helper'
+
+describe 'gitlab_ci_runner::runner' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+      let(:title) { 'testrunner' }
+      let(:default_params) do
+        {
+          config: {
+            'registration-token' => 'gitlab-token',
+            'url'                => 'https://gitlab.com'
+          }
+        }
+      end
+
+      context 'with default params' do
+        let(:params) { default_params }
+
+        it { is_expected.to compile.with_all_deps }
+
+        it do
+          is_expected.to contain_exec('Register_runner_testrunner').with(
+            command: '/usr/bin/gitlab-runner register -n --registration-token=gitlab-token --url=https://gitlab.com',
+            unless: "/bin/grep -F 'testrunner' /etc/gitlab-runner/config.toml"
+          )
+        end
+      end
+
+      context 'with ensure => absent' do
+        let(:params) do
+          default_params.merge(ensure: 'absent')
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        it do
+          is_expected.to contain_exec('Unregister_runner_testrunner').with(
+            command: '/usr/bin/gitlab-runner unregister -n testrunner',
+            onlyif: "/bin/grep 'testrunner' /etc/gitlab-runner/config.toml"
+          )
+        end
+      end
+
+      context 'with runner_name/title including a _' do
+        let(:title) { 'test_runner' }
+        let(:params) { default_params }
+
+        context 'with ensure => present' do
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_exec('Register_runner_test_runner').with_unless(%r{^/bin/grep -F 'test-runner'}) }
+        end
+
+        context 'with ensure => absent' do
+          let(:params) do
+            super().merge(ensure: 'absent')
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_exec('Unregister_runner_test_runner').with_onlyif(%r{^/bin/grep 'test-runner'}) }
+        end
+      end
+
+      context 'with binary => special-gitlab-runner' do
+        let(:params) { default_params.merge(binary: 'special-gitlab-runner') }
+
+        context 'with ensure => present' do
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_exec('Register_runner_testrunner').with_command(%r{^/usr/bin/special-gitlab-runner}) }
+        end
+
+        context 'with ensure => absent' do
+          let(:params) do
+            super().merge(ensure: 'absent')
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_exec('Unregister_runner_testrunner').with_command(%r{^/usr/bin/special-gitlab-runner}) }
+        end
+      end
+
+      context 'with config having a key containing _' do
+        let(:params) do
+          {
+            config: {
+              build_dir: '/tmp'
+            }
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_exec('Register_runner_testrunner').with_command(%r{--build-dir=/tmp}) }
+      end
+
+      context 'with config having a key which has an array as value' do
+        let(:params) do
+          {
+            config: {
+              'docker-volumes' => ['test0:/test0', 'test1:/test1']
+            }
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_exec('Register_runner_testrunner').with_command(%r{--docker-volumes=test0:/test0 --docker-volumes=test1:/test1}) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description
Before this, the complete hash with all runners was injected into
gitlab_ci_runner::runner. Based on the title of the resource it was then
decided which runner should be extracted from the global hash and merge
with defaults ect.

This was completely refactored in a way that a single
gitlab_ci_runner::runner resource now only holds all data which is need
to configure it but no other.

This also changes the default of gitlab_ci_runner::runners(_defaults) to
an empty hash because I don't see why we need to force user to configure
it.

I've added the label "backwards-incompatible" because I clearly break the complete interface of `gitlab_ci_runner::runner`. Sorry, I don't see any other way. It just doesn't make sense in a Puppet > 3 world. However, the interface provided by the init.pp to configure runners should still be complete intact.

#### This Pull Request (PR) fixes the following issues

