### PR TITLE
Make manage_docker optional and include the docker module if used

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -127,7 +127,7 @@ Data type: `Boolean`
 
 If docker should be installs (uses the puppetlabs-docker).
 
-Default value: `true`
+Default value: `false`
 
 ##### `manage_repo`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,7 +54,7 @@ class gitlab_ci_runner (
   Optional[Pattern[/.*:.+/]] $metrics_server           = undef,
   Optional[Pattern[/.*:.+/]] $listen_address           = undef,
   Optional[String]           $sentry_dsn               = undef,
-  Boolean                    $manage_docker            = true,
+  Boolean                    $manage_docker            = false,
   Boolean                    $manage_repo              = true,
   String                     $package_ensure           = installed,
   String                     $package_name             = 'gitlab-runner',
@@ -73,6 +73,8 @@ class gitlab_ci_runner (
         image_tag => 'trusty',
       },
     }
+
+    include docker
     class { 'docker::images':
       images => $docker_images,
     }


### PR DESCRIPTION
#### Pull Request (PR) description
We need to include the complete docker module to ensure docker is
installed on the host to be able to use `docker::images`.

Docker is by far not a required dependency for a Gitlab Runner instance
and should therefore not be installed/configured by default. This also
makes everything easier because we still support CentOS 6 and
puppetlabs-docker doesn't.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
