### PR TITLE
Switch from Ubuntu Trusty to Ubuntu Focal

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ gitlab_ci_runner::runner_defaults:
   url: "https://git.example.com/ci"
   registration-token: "1234567890abcdef"
   executor: "docker"
-  docker-image: "ubuntu:trusty"
+  docker-image: "ubuntu:focal"
   builds_dir: "/tmp"
   cache_dir: "/tmp"
 ```

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,9 +68,9 @@ class gitlab_ci_runner (
     ensure_packages($xz_package_name)
 
     $docker_images = {
-      ubuntu_trusty => {
+      ubuntu_focal => {
         image     => 'ubuntu',
-        image_tag => 'trusty',
+        image_tag => 'focal',
       },
     }
 

--- a/spec/classes/gitlab_ci_runner_spec.rb
+++ b/spec/classes/gitlab_ci_runner_spec.rb
@@ -184,9 +184,9 @@ describe 'gitlab_ci_runner', type: :class do
             is_expected.to contain_class('docker::images').
               with(
                 images: {
-                  'ubuntu_trusty' => {
+                  'ubuntu_focal' => {
                     'image'     => 'ubuntu',
-                    'image_tag' => 'trusty'
+                    'image_tag' => 'focal'
                   }
                 }
               )


### PR DESCRIPTION
Ubuntu Trusty has been out of support since April 2019, it seems
most sensible to update this to the latest LTS release which is
20.04 Focal Fossa.