### PR TITLE
Fix CI problems

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,7 +15,7 @@ class gitlab_ci_runner::config (
   assert_private()
 
   file { $config_path: # ensure config exists
-    ensure  => 'present',
+    ensure  => 'file',
     replace => 'no',
     content => '',
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,7 +61,7 @@ class gitlab_ci_runner (
   Stdlib::HTTPUrl            $repo_base_url            = 'https://packages.gitlab.com',
   Optional[Stdlib::Fqdn]     $repo_keyserver           = undef,
   String                     $config_path              = '/etc/gitlab-runner/config.toml',
-){
+) {
   if $manage_docker {
     # workaround for cirunner issue #1617
     # https://gitlab.com/gitlab-org/gitlab-ci-multi-runner/issues/1617

--- a/manifests/runner.pp
+++ b/manifests/runner.pp
@@ -52,13 +52,13 @@ define gitlab_ci_runner::runner (
 
   if $ensure == 'absent' {
     # Execute gitlab ci multirunner unregister
-    exec {"Unregister_runner_${title}":
+    exec { "Unregister_runner_${title}":
       command => "/usr/bin/${binary} unregister -n ${_name}",
       onlyif  => "/bin/grep -F \'${_name}\' /etc/gitlab-runner/config.toml",
     }
   } else {
     # Execute gitlab ci multirunner register
-    exec {"Register_runner_${title}":
+    exec { "Register_runner_${title}":
       command => "/usr/bin/${binary} register -n ${__config}",
       unless  => "/bin/grep -F \'${_name}\' /etc/gitlab-runner/config.toml",
     }

--- a/spec/classes/gitlab_ci_runner_spec.rb
+++ b/spec/classes/gitlab_ci_runner_spec.rb
@@ -224,7 +224,7 @@ describe 'gitlab_ci_runner', type: :class do
           end
         when 'RedHat'
           os_release_version = if facts[:os]['name'] == 'Amazon'
-                                 if facts[:os]['release']['major'] == 2
+                                 if facts[:os]['release']['major'] == '2'
                                    '7'
                                  else
                                    '6'


### PR DESCRIPTION
Fixes for CI problems flagged on https://travis-ci.org/github/voxpupuli/puppet-gitlab_ci_runner/jobs/710915386

```
manifests/config.pp:18:file_ensure:WARNING:ensure set to present on file resource
manifests/init.pp:64:manifest_whitespace_opening_brace_before:ERROR:there should be a single space before an opening brace
manifests/runner.pp:55:manifest_whitespace_opening_brace_after:ERROR:there should be a single space or single newline after an opening brace
manifests/runner.pp:61:manifest_whitespace_opening_brace_after:ERROR:there should be a single space or single newline after an opening brace
```

and the Amazon version check from https://travis-ci.org/github/voxpupuli/puppet-gitlab_ci_runner/jobs/710919276

Where it appears that the version is being passed in as a String with Ruby 2.4 Puppet 5, not an Integer.
