### PR TITLE
Allow management of check_interval config setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ To use the Gitlab CI runners it is required to have the [puppetlabs/docker](http
 ```yaml
 gitlab_ci_runner::concurrent: 4
 
+gitlab_ci_runner::check_interval: 4
+
 gitlab_ci_runner::metrics_server: "localhost:8888"
 
 gitlab_ci_runner::manage_docker: true

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,6 +5,7 @@
 class gitlab_ci_runner::config (
   $config_path    = $gitlab_ci_runner::config_path,
   $concurrent     = $gitlab_ci_runner::concurrent,
+  $check_interval = $gitlab_ci_runner::check_interval,
   $metrics_server = $gitlab_ci_runner::metrics_server,
   $listen_address = $gitlab_ci_runner::listen_address,
   $builds_dir     = $gitlab_ci_runner::builds_dir,
@@ -25,6 +26,14 @@ class gitlab_ci_runner::config (
       path  => $config_path,
       line  => "concurrent = ${concurrent}",
       match => '^concurrent = \d+',
+    }
+  }
+
+  if $check_interval {
+    file_line { 'gitlab-runner-check-interval':
+      path  => $config_path,
+      line  => "check_interval = ${check_interval}",
+      match => '^check_interval = \d+',
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,8 @@
 #   The name of the 'xz' package. Needed for local docker installations.
 # @param concurrent
 #   Limits how many jobs globally can be run concurrently. The most upper limit of jobs using all defined runners. 0 does not mean unlimited!
+# @param check_interval
+#   Integer which defines the interval length, in seconds, between new jobs check. If not set via Puppet the default value is 3; if set to 0 or lower, GitLab runner will use the default value.
 # @param builds_dir
 #   Absolute path to a directory where builds will be stored in context of selected executor (Locally, Docker, SSH).
 # @param cache_dir
@@ -49,6 +51,7 @@ class gitlab_ci_runner (
   Hash                       $runners                  = {},
   Hash                       $runner_defaults          = {},
   Optional[Integer]          $concurrent               = undef,
+  Optional[Integer]          $check_interval           = undef,
   Optional[String]           $builds_dir               = undef,
   Optional[String]           $cache_dir                = undef,
   Optional[Pattern[/.*:.+/]] $metrics_server           = undef,

--- a/spec/classes/gitlab_ci_runner_spec.rb
+++ b/spec/classes/gitlab_ci_runner_spec.rb
@@ -39,6 +39,7 @@ describe 'gitlab_ci_runner', type: :class do
       it { is_expected.to contain_file('/etc/gitlab-runner/config.toml') }
 
       it { is_expected.not_to contain_file_line('gitlab-runner-concurrent') }
+      it { is_expected.not_to contain_file_line('gitlab-runner-check-interval') }
       it { is_expected.not_to contain_file_line('gitlab-runner-metrics_server') }
       it { is_expected.not_to contain_file_line('gitlab-runner-builds_dir') }
       it { is_expected.not_to contain_file_line('gitlab-runner-cache_dir') }
@@ -56,6 +57,21 @@ describe 'gitlab_ci_runner', type: :class do
           is_expected.to contain_file_line('gitlab-runner-concurrent').with('path' => '/etc/gitlab-runner/config.toml',
                                                                             'line'  => 'concurrent = 10',
                                                                             'match' => '^concurrent = \d+')
+        end
+      end
+      context 'with check_interval => 10' do
+        let(:params) do
+          {
+            'runner_defaults' => {},
+            'runners' => {},
+            'check_interval' => 10
+          }
+        end
+
+        it do
+          is_expected.to contain_file_line('gitlab-runner-check-interval').with('path' => '/etc/gitlab-runner/config.toml',
+                                                                                'line'  => 'check_interval = 10',
+                                                                                'match' => '^check_interval = \d+')
         end
       end
       context 'with metrics_server => localhost:9252' do


### PR DESCRIPTION
#### Pull Request (PR) description

At the moment, the check_interval setting must be done by a local
(profile) file_line setting.
This patch allows management of the check_interval setting directly via
this module.
Default behavior is to not manage the check_interval setting.

#### This Pull Request (PR) fixes the following issues

none
