### PR TITLE
implement support for config file/dir permission management.

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -86,6 +86,11 @@ The following parameters are available in the `gitlab_ci_runner` class:
 * [`repo_base_url`](#repo_base_url)
 * [`repo_keyserver`](#repo_keyserver)
 * [`config_path`](#config_path)
+* [`config_owner`](#config_owner)
+* [`config_group`](#config_group)
+* [`config_mode`](#config_mode)
+* [`manage_config_dir`](#manage_config_dir)
+* [`config_dir_mode`](#config_dir_mode)
 * [`http_proxy`](#http_proxy)
 * [`ca_file`](#ca_file)
 
@@ -222,6 +227,48 @@ Data type: `String`
 The path to the config file of Gitlab runner.
 
 Default value: `'/etc/gitlab-runner/config.toml'`
+
+##### <a name="config_owner"></a>`config_owner`
+
+Data type: `Optional[String[1]]`
+
+The user owning the config file.
+(and config directory if managed).
+
+Default value: ``undef``
+
+##### <a name="config_group"></a>`config_group`
+
+Data type: `Optional[String[1]]`
+
+The group ownership assigned to the config file
+(and config directory if managed).
+
+Default value: ``undef``
+
+##### <a name="config_mode"></a>`config_mode`
+
+Data type: `Optional[Stdlib::Filemode]`
+
+The file permissions applied to the config file.
+
+Default value: ``undef``
+
+##### <a name="manage_config_dir"></a>`manage_config_dir`
+
+Data type: `Boolean`
+
+Manage the parent directory of the config file.
+
+Default value: ``false``
+
+##### <a name="config_dir_mode"></a>`config_dir_mode`
+
+Data type: `Optional[Stdlib::Filemode]`
+
+The file permissions applied to the config directory.
+
+Default value: ``undef``
 
 ##### <a name="http_proxy"></a>`http_proxy`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,6 +4,11 @@
 #
 class gitlab_ci_runner::config (
   $config_path    = $gitlab_ci_runner::config_path,
+  $config_owner      = $gitlab_ci_runner::config_owner,
+  $config_group      = $gitlab_ci_runner::config_group,
+  $config_mode       = $gitlab_ci_runner::config_mode,
+  $manage_config_dir = $gitlab_ci_runner::manage_config_dir,
+  $config_dir_mode   = $gitlab_ci_runner::config_dir_mode,
   $concurrent     = $gitlab_ci_runner::concurrent,
   $log_level      = $gitlab_ci_runner::log_level,
   $log_format     = $gitlab_ci_runner::log_format,
@@ -17,9 +22,9 @@ class gitlab_ci_runner::config (
 
   concat { $config_path:
     ensure         => present,
-    owner          => 'root',
-    group          => 'root',
-    mode           => '0444',
+    owner          => $config_owner,
+    group          => $config_group,
+    mode           => $config_mode,
     ensure_newline => true,
   }
 
@@ -43,5 +48,16 @@ class gitlab_ci_runner::config (
     target  => $config_path,
     order   => 1,
     content => gitlab_ci_runner::to_toml($global_options),
+  }
+
+  if $manage_config_dir {
+    $_config_dir = dirname($config_path)
+
+    file { $_config_dir:
+      ensure => 'directory',
+      owner  => $config_owner,
+      group  => $config_group,
+      mode   => $config_dir_mode,
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,18 @@
 #   The keyserver which should be used to get the repository key.
 # @param config_path
 #   The path to the config file of Gitlab runner.
+# @param config_owner
+#   The user owning the config file.
+#   (and config directory if managed).
+# @param config_group
+#   The group ownership assigned to the config file
+#   (and config directory if managed).
+# @param config_mode
+#   The file permissions applied to the config file.
+# @param manage_config_dir
+#   Manage the parent directory of the config file.
+# @param config_dir_mode
+#   The file permissions applied to the config directory.
 # @param http_proxy
 #   An HTTP proxy to use whilst registering runners.
 #   This setting is only used when registering or unregistering runners and will be used for all runners in the `runners` parameter.
@@ -79,6 +91,11 @@ class gitlab_ci_runner (
   Stdlib::HTTPUrl                            $repo_base_url   = 'https://packages.gitlab.com',
   Optional[Gitlab_ci_runner::Keyserver]      $repo_keyserver  = undef,
   String                                     $config_path     = '/etc/gitlab-runner/config.toml',
+  String[1]                                  $config_owner    = 'root',
+  String[1]                                  $config_group    = 'root',
+  Stdlib::Filemode                           $config_mode     = '0444',
+  Boolean                                    $manage_config_dir = false,
+  Optional[Stdlib::Filemode]                 $config_dir_mode = undef,
   Optional[Stdlib::HTTPUrl]                  $http_proxy      = undef,
   Optional[Stdlib::Unixpath]                 $ca_file         = undef,
 ) {

--- a/spec/classes/gitlab_ci_runner_spec.rb
+++ b/spec/classes/gitlab_ci_runner_spec.rb
@@ -103,6 +103,58 @@ describe 'gitlab_ci_runner', type: :class do
         it { is_expected.to contain_gitlab_ci_runner__runner('runner_with_ensure_absent').with_ensure('absent') }
       end
 
+      context 'with config permissions' do
+        let(:params) do
+          {
+            'runner_defaults' => {},
+            'runners' => {},
+            'config_owner' => 'gitlab-runner',
+            'config_group' => 'gitlab-runner',
+            'config_mode' => '0640'
+          }
+        end
+
+        it do
+          is_expected.to contain_concat('/etc/gitlab-runner/config.toml').with('owner' => 'gitlab-runner',
+                                                                               'group' => 'gitlab-runner',
+                                                                               'mode'  => '0640')
+        end
+      end
+
+      context 'with manage_config_dir => true' do
+        let(:params) do
+          {
+            'runner_defaults' => {},
+            'runners' => {},
+            'manage_config_dir' => true
+          }
+        end
+
+        it do
+          is_expected.to contain_file('/etc/gitlab-runner').with('ensure' => 'directory')
+        end
+      end
+
+      context 'with config dir permissions' do
+        let(:params) do
+          {
+            'runner_defaults' => {},
+            'runners' => {},
+            'manage_config_dir' => true,
+            'config_owner' => 'gitlab-runner',
+            'config_group' => 'gitlab-runner',
+            'config_dir_mode' => '0750'
+          }
+        end
+
+        it do
+          is_expected.to contain_file('/etc/gitlab-runner').with('ensure' => 'directory',
+                                                                 'owner' => 'gitlab-runner',
+                                                                 'group' => 'gitlab-runner',
+                                                                 'mode'  => '0750')
+        end
+      end
+
       context 'with concurrent => 10' do
         let(:params) do
           {


### PR DESCRIPTION

#### Pull Request (PR) description

the gitlab-runner package creates the config file with ownership root:root
and a restrictive permission mask of 077. the puppet module already manages
the file, althoug only its mere existence. this PR adds support for managing
the ownership and permissions of both the config file iteself and its parent directory.
both management options are optional and backwards compatible.
