### PR TITLE
Adding the option to disable the '_' to '-' replacement in configuration

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,6 +3,7 @@ fixtures:
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     apt: "https://github.com/puppetlabs/puppetlabs-apt.git"
     docker: "https://github.com/puppetlabs/puppetlabs-docker.git"
+    translate: "https://github.com/puppetlabs/puppetlabs-translate.git"
     yumrepo_core:
       repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
       puppet_version: ">= 6.0.0"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ To use the Gitlab CI runners it is required to have the [puppetlabs/docker](http
 
 `$manage_docker` can be set to false if docker is managed externally.
 
+`$manage_compat` should be set to false in new configurations, as it allows access to configuration keys that have a '\_' in their name.
+
 ```yaml
 gitlab_ci_runner::concurrent: 4
 
@@ -34,6 +36,8 @@ gitlab_ci_runner::metrics_server: "localhost:8888"
 gitlab_ci_runner::manage_docker: true
 
 gitlab_ci_runner::config_path: "etc/gitlab-runner/config.toml"
+
+gitlab_ci_runner::config_compat: false
 
 gitlab_ci_runner::runners:
   test_runner1:{}
@@ -48,8 +52,8 @@ gitlab_ci_runner::runner_defaults:
   registration-token: "1234567890abcdef"
   executor: "docker"
   docker-image: "ubuntu:focal"
-  builds_dir: "/tmp"
-  cache_dir: "/tmp"
+  builds-dir: "/tmp"
+  cache-dir: "/tmp"
 ```
 
 To unregister a specific runner you may use `ensure` param:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,8 @@
 #   The keyserver which should be used to get the repository key.
 # @param config_path
 #   The path to the config file of Gitlab runner.
+# @param config_compat
+#   The '_' are substituted with '-', this prohibits the use of some keys i.e. "custom_build_dir-enabled", set false to disable substitution.
 #
 class gitlab_ci_runner (
   String                     $xz_package_name, # Defaults in module hieradata
@@ -64,6 +66,7 @@ class gitlab_ci_runner (
   Stdlib::HTTPUrl            $repo_base_url            = 'https://packages.gitlab.com',
   Optional[Stdlib::Fqdn]     $repo_keyserver           = undef,
   String                     $config_path              = '/etc/gitlab-runner/config.toml',
+  Boolean                    $config_compat            = true,
 ) {
   if $manage_docker {
     # workaround for cirunner issue #1617
@@ -104,11 +107,12 @@ class gitlab_ci_runner (
     }
 
     gitlab_ci_runner::runner { $title:
-      ensure  => $ensure,
-      config  => $_config - ['ensure', 'name'],
-      binary  => $package_name,
-      require => Class['gitlab_ci_runner::config'],
-      notify  => Class['gitlab_ci_runner::service'],
+      ensure        => $ensure,
+      config        => $_config - ['ensure', 'name'],
+      config_compat => $config_compat,
+      binary        => $package_name,
+      require       => Class['gitlab_ci_runner::config'],
+      notify        => Class['gitlab_ci_runner::service'],
     }
   }
 }

--- a/manifests/runner.pp
+++ b/manifests/runner.pp
@@ -22,6 +22,7 @@
 define gitlab_ci_runner::runner (
   Hash                      $config,
   Enum['present', 'absent'] $ensure      = 'present',
+  Boolean                   $config_compat = true,
   String[1]                 $runner_name = $title,
   String[1]                 $binary      = 'gitlab-runner',
 ) {
@@ -37,8 +38,11 @@ define gitlab_ci_runner::runner (
   #
   # In the end, flatten thewhole array and join all elements with a space as delimiter
   $__config = $_config.map |$item| {
-    # Ensure all keys use '-' instead of '_'. Needed for e.g. build_dir.
-    $key = regsubst($item[0], '_', '-', 'G')
+    if $config_compat {
+      $key = regsubst($item[0], '_', '-', 'G')
+    } else {
+      $key = $item[0]
+    }
 
     # If the value ($item[1]) is an Array multiple elements are added for each item
     if $item[1] =~ Array {


### PR DESCRIPTION
This breaks keys in the runner config, which has command line options that contain a '_'.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
