### PR TITLE
Allow `hkp://` style URLs for `repo_keyserver` URL

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,7 +59,7 @@ class gitlab_ci_runner (
   String                                 $package_ensure  = installed,
   String                                 $package_name    = 'gitlab-runner',
   Stdlib::HTTPUrl                        $repo_base_url   = 'https://packages.gitlab.com',
-  Optional[Stdlib::Fqdn]                 $repo_keyserver  = undef,
+  Optional[Gitlab_ci_runner::Keyserver]  $repo_keyserver   = undef,
   String                                 $config_path     = '/etc/gitlab-runner/config.toml',
 ) {
   if $manage_docker {

--- a/spec/classes/gitlab_ci_runner_spec.rb
+++ b/spec/classes/gitlab_ci_runner_spec.rb
@@ -291,6 +291,7 @@ describe 'gitlab_ci_runner', type: :class do
       end
 
       if facts[:os]['family'] == 'Debian'
+        # <= v3.0.0
         context 'with manage_repo => true and repo_keyserver => keys.gnupg.net' do
           let(:params) do
             super().merge(
@@ -304,6 +305,38 @@ describe 'gitlab_ci_runner', type: :class do
 
           it do
             is_expected.to contain_apt__source('apt_gitlabci').with_key('id' => 'F6403F6544A38863DAA0B6E03F01618A51312F3F', 'server' => 'keys.gnupg.net')
+          end
+        end
+
+        # allowed > 3.0.0 (see issue #101)
+        context 'with manage_repo => true and repo_keyserver => hkp://keys.gnupg.net:80' do
+          let(:params) do
+            super().merge(
+              manage_repo: true,
+              repo_keyserver: 'hkp://keys.gnupg.net:80'
+            )
+          end
+
+          it { is_expected.to compile }
+          it { is_expected.to contain_class('gitlab_ci_runner::repo') }
+
+          it do
+            is_expected.to contain_apt__source('apt_gitlabci').with_key('id' => 'F6403F6544A38863DAA0B6E03F01618A51312F3F', 'server' => 'hkp://keys.gnupg.net:80')
+          end
+        end
+        context 'with manage_repo => true and repo_keyserver => https://keys.gnupg.net:88' do
+          let(:params) do
+            super().merge(
+              manage_repo: true,
+              repo_keyserver: 'https://keys.gnupg.net:88'
+            )
+          end
+
+          it { is_expected.to compile }
+          it { is_expected.to contain_class('gitlab_ci_runner::repo') }
+
+          it do
+            is_expected.to contain_apt__source('apt_gitlabci').with_key('id' => 'F6403F6544A38863DAA0B6E03F01618A51312F3F', 'server' => 'https://keys.gnupg.net:88')
           end
         end
       end

--- a/types/keyserver.pp
+++ b/types/keyserver.pp
@@ -1,0 +1,4 @@
+# Type to match repo_keyserver
+# Regex from: https://github.com/puppetlabs/puppetlabs-apt/blob/main/manifests/key.pp
+type Gitlab_ci_runner::Keyserver = Pattern[/\A((hkp|hkps|http|https):\/\/)?([a-z\d])([a-z\d-]{0,61}\.)+[a-z\d]+(:\d{2,5})?(\/[a-zA-Z\d\-_.]+)*\/?$/]
+


### PR DESCRIPTION
Fixes voxpupuli/puppet-gitlab_ci_runner#101

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
