### PR TITLE
Fix broken master CI

### DIFF
--- a/spec/acceptance/gitlab_ci_runner_spec.rb
+++ b/spec/acceptance/gitlab_ci_runner_spec.rb
@@ -39,7 +39,7 @@ describe 'gitlab_ci_runner class' do
     it 'registered the runner' do
       authtoken = shell("grep 'token = ' /etc/gitlab-runner/config.toml | cut -d '\"' -f2").stdout
       shell("/usr/bin/env curl -X POST --form 'token=#{authtoken}' http://gitlab/api/v4/runners/verify") do |r|
-        expect(r.stdout).to eq('200')
+        expect(r.stdout).to eq('"200"')
       end
     end
   end

--- a/spec/classes/gitlab_ci_runner_spec.rb
+++ b/spec/classes/gitlab_ci_runner_spec.rb
@@ -184,8 +184,8 @@ describe 'gitlab_ci_runner', type: :class do
         it { is_expected.not_to contain_exec('Unregister_runner_test_runner').with('command' => %r{--ensure=}) }
       end
 
-      # puppetlabs-docker doesn't support CentOS 6 anymore.
-      unless facts[:os]['name'] == 'CentOS' && facts[:os]['release']['major'] == '6'
+      # puppetlabs-docker doesn't support CentOS (and derivatives) 6 anymore.
+      unless facts[:os]['family'] == 'RedHat' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '7') < 0
         context 'with manage_docker => true' do
           let(:params) do
             {

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -31,28 +31,25 @@ configure_beaker do |host|
   # Setup Puppet Bolt
   gitlab_ip = File.read(File.expand_path('~/GITLAB_IP')).chomp
   bolt = <<-MANIFEST
-  $bolt_config = @("GITCONFIG"/L)
+  $bolt_config = @("BOLTPROJECT"/L)
   modulepath: "/etc/puppetlabs/code/modules:/etc/puppetlabs/code/environments/production/modules"
-  ssh:
-    host-key-check: false
-    user: root
-    password: root
-  | GITCONFIG
+  analytics: false
+  | BOLTPROJECT
 
   package { 'puppet-bolt':
     ensure => installed,
   }
 
-  file { [ '/root/.puppetlabs', '/root/.puppetlabs/bolt']:
+  file { [ '/root/.puppetlabs', '/root/.puppetlabs/bolt', '/root/.puppetlabs/etc', '/root/.puppetlabs/etc/bolt']:
     ensure => directory,
   }
 
-  file { '/root/.puppetlabs/bolt/analytics.yaml':
+  # Needs to existing to not trigger a warning sign...
+  file { '/root/.puppetlabs/etc/bolt/analytics.yaml':
     ensure  => file,
-    content => "disabled: true\n",
   }
 
-  file { '/root/.puppetlabs/bolt/bolt.yaml':
+  file { '/root/.puppetlabs/bolt/bolt-project.yaml':
     ensure  => file,
     content => $bolt_config,
   }


### PR DESCRIPTION

#### Pull Request (PR) description
This fixes 3 issues which currently block the CI. Different reasons:

* facterdb seems to have added support for Amazon OS 2 and Scientific Linux 6. Both do not support puppetlabs-docker and need therefore be excluded from tests
* Bolt configuration changed due to a new version which introduced different config files.
* The Gitlab api/v4/runners/verify response seems to be quoted in newer version

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
