### PR TITLE
Remove travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Gitlab-CI runner module for Puppet
 
-[![Build Status](https://travis-ci.org/voxpupuli/puppet-gitlab_ci_runner.png?branch=master)](https://travis-ci.org/voxpupuli/puppet-gitlab_ci_runner)
 [![Puppet Forge](https://img.shields.io/puppetforge/v/puppet/gitlab_ci_runner.svg)](https://forge.puppetlabs.com/puppet/gitlab_ci_runner)
 [![Puppet Forge - downloads](https://img.shields.io/puppetforge/dt/puppet/gitlab_ci_runner.svg)](https://forge.puppetlabs.com/puppet/gitlab_ci_runner)
 [![Puppet Forge - endorsement](https://img.shields.io/puppetforge/e/puppet/gitlab_ci_runner.svg)](https://forge.puppetlabs.com/puppet/gitlab_ci_runner)


### PR DESCRIPTION
We use github workflows now.