### PR TITLE
Add support for registration by leveraging a "Deferred" function

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -3,7 +3,6 @@ Gemfile:
   optional:
     ':test':
       - gem: 'webmock'
-      - gem: 'toml-rb'
 spec/spec_helper.rb:
   spec_overrides:
   - require 'spec_helper_local'

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ group :test do
   gem 'coveralls',                 :require => false
   gem 'simplecov-console',         :require => false
   gem 'webmock',                   :require => false
-  gem 'toml-rb',                   :require => false
 end
 
 group :development do

--- a/README.md
+++ b/README.md
@@ -71,3 +71,7 @@ The Gitlab CI runner installation is at the moment only tested on:
 * Ubuntu 16.04/18.04
 
 A runner configuration is currently only applied if the specific runner does not exist in the config file.
+
+## License
+
+[lib/puppet_x/gitlab/dumper.rb](lib/puppet_x/gitlab/dumper.rb) is licensed under MIT. All other code is licensed under Apache 2.0.

--- a/lib/puppet/functions/gitlab_ci_runner/register.rb
+++ b/lib/puppet/functions/gitlab_ci_runner/register.rb
@@ -1,0 +1,24 @@
+require_relative '../../../puppet_x/gitlab/runner.rb'
+
+# A function that registers a Gitlab runner on a Gitlab instance. Be careful, this will be triggered on noop runs as well!
+Puppet::Functions.create_function(:'gitlab_ci_runner::register') do
+  # @param url The url to your Gitlab instance. Please only provide the host part (e.g https://gitlab.com)
+  # @param token Registration token.
+  # @param additional_options A hash with all additional configuration options for that runner
+  # @return [Struct[{ id => Integer[1], token => String[1], }]] Returns a hash with the runner id and authentcation token
+  # @example Using it as a replacement for the Bolt 'register_runner' task
+  #   puppet apply -e "notice(gitlab_ci_runner::register('https://gitlab.com', 'registration-token'))"
+  #
+  dispatch :register do
+    param 'Stdlib::HTTPUrl', :url
+    param 'String[1]', :token
+    optional_param 'Gitlab_ci_runner::Register', :additional_options
+    return_type 'Struct[{ id => Integer[1], token => String[1], }]'
+  end
+
+  def register(url, token, additional_options = {})
+    PuppetX::Gitlab::Runner.register(url, additional_options.merge('token' => token))
+  rescue Net::HTTPError => e
+    raise "Gitlab runner failed to register: #{e.message}"
+  end
+end

--- a/lib/puppet/functions/gitlab_ci_runner/register_to_file.rb
+++ b/lib/puppet/functions/gitlab_ci_runner/register_to_file.rb
@@ -1,0 +1,57 @@
+require_relative '../../../puppet_x/gitlab/runner.rb'
+require 'fileutils'
+
+# A function that registers a Gitlab runner on a Gitlab instance, if it doesn't already exist,
+# _and_ saves the retrieved authentication token to a file. This is helpful for Deferred functions.
+Puppet::Functions.create_function(:'gitlab_ci_runner::register_to_file') do
+  # @param url The url to your Gitlab instance. Please only provide the host part (e.g https://gitlab.com)
+  # @param regtoken Registration token.
+  # @param runner_name The name of the runner. Use as identifier for the retrieved auth token.
+  # @param filename The filename where the token should be saved.
+  # @param additional_options A hash with all additional configuration options for that runner
+  # @return [String] Returns the authentication token
+  # @example Using it as a Deferred function
+  #   gitlab_ci_runner::runner { 'testrunner':
+  #     config               => {
+  #       'url'              => 'https://gitlab.com',
+  #       'token'            => Deferred('gitlab_ci_runner::register_runner_to_file', [$config['url'], $config['registration-token'], 'testrunner'])
+  #       'executor'         => 'shell',
+  #     },
+  #   }
+  #
+  dispatch :register_to_file do
+    # We use only core data types because others aren't synced to the agent.
+    param 'String[1]', :url
+    param 'String[1]', :regtoken
+    param 'String[1]', :runner_name
+    optional_param 'Hash', :additional_options
+    optional_param 'String[1]', :filename
+    return_type 'String[1]'
+  end
+
+  def register_to_file(url, regtoken, runner_name, additional_options = {}, filename = "/etc/gitlab-runner/auth-token-#{runner_name}")
+    if File.exist?(filename)
+      authtoken = File.read(filename).strip
+    else
+      return 'DUMMY-NOOP-TOKEN' if Puppet.settings[:noop]
+      begin
+        authtoken = PuppetX::Gitlab::Runner.register(url, additional_options.merge('token' => regtoken))['token']
+
+        # If this function is used as a Deferred function the Gitlab Runner config dir
+        # will not exist on the first run, because the package isn't installed yet.
+        dirname = File.dirname(filename)
+        unless File.exist?(dirname)
+          FileUtils.mkdir_p(File.dirname(filename))
+          File.chmod(0o700, dirname)
+        end
+
+        File.write(filename, authtoken)
+        File.chmod(0o400, filename)
+      rescue Net::HTTPError => e
+        raise "Gitlab runner failed to register: #{e.message}"
+      end
+    end
+
+    authtoken
+  end
+end

--- a/lib/puppet/functions/gitlab_ci_runner/to_toml.rb
+++ b/lib/puppet/functions/gitlab_ci_runner/to_toml.rb
@@ -1,0 +1,21 @@
+require_relative '../../../puppet_x/gitlab/dumper.rb'
+# @summary Convert a data structure and output to TOML.
+#
+# @example How to output TOML to a file
+#   file { '/tmp/config.toml':
+#     ensure  => file,
+#     content => to_toml($myhash),
+#   }
+#
+Puppet::Functions.create_function(:'gitlab_ci_runner::to_toml') do
+  # @param data Data structure which needs to be converted into TOML
+  # @return [String] Converted data as TOML string
+  dispatch :to_toml do
+    required_param 'Hash', :data
+    return_type 'String'
+  end
+
+  def to_toml(data)
+    PuppetX::Gitlab::Dumper.new(data).toml_str
+  end
+end

--- a/lib/puppet/functions/gitlab_ci_runner/unregister.rb
+++ b/lib/puppet/functions/gitlab_ci_runner/unregister.rb
@@ -1,0 +1,24 @@
+require_relative '../../../puppet_x/gitlab/runner.rb'
+
+# A function that unregisters a Gitlab runner from a Gitlab instance. Be careful, this will be triggered on noop runs as well!
+Puppet::Functions.create_function(:'gitlab_ci_runner::unregister') do
+  # @summary A function that unregisters a Gitlab runner from a Gitlab instance. Be careful, this will be triggered on noop runs as well!
+  # @param url The url to your Gitlab instance. Please only provide the host part (e.g https://gitlab.com)
+  # @param token Runners authentication token.
+  # @return [Struct[{ id => Integer[1], token => String[1], }]] Returns a hash with the runner id and authentcation token
+  # @example Using it as a replacement for the Bolt 'unregister_runner' task
+  #   puppet apply -e "notice(gitlab_ci_runner::unregister('https://gitlab.com', 'runner-auth-token'))"
+  #
+  dispatch :unregister do
+    param 'Stdlib::HTTPUrl', :url
+    param 'String[1]', :token
+    return_type "Struct[{ status => Enum['success'], }]"
+  end
+
+  def unregister(url, token)
+    PuppetX::Gitlab::Runner.unregister(url, token: token)
+    { 'status' => 'success' }
+  rescue Net::HTTPError => e
+    raise "Gitlab runner failed to unregister: #{e.message}"
+  end
+end

--- a/lib/puppet/functions/gitlab_ci_runner/unregister_from_file.rb
+++ b/lib/puppet/functions/gitlab_ci_runner/unregister_from_file.rb
@@ -1,0 +1,28 @@
+require_relative '../../../puppet_x/gitlab/runner.rb'
+
+# A function that unregisters a Gitlab runner from a Gitlab instance, if the local token is there.
+# This is meant to be used in conjunction with the gitlab_ci_runner::register_to_file function.
+Puppet::Functions.create_function(:'gitlab_ci_runner::unregister_from_file') do
+  # @param url The url to your Gitlab instance. Please only provide the host part (e.g https://gitlab.com)
+  # @param runner_name The name of the runner. Use as identifier for the retrived auth token.
+  # @param filename The filename where the token should be saved.
+  # @example Using it as a Deferred function with a file resource
+  #   file { '/etc/gitlab-runner/auth-token-testrunner':
+  #     file    => absent,
+  #     content => Deferred('gitlab_ci_runner::unregister_from_file', ['http://gitlab.example.org'])
+  #   }
+  #
+  dispatch :unregister_to_file do
+    # We use only core data types because others aren't synced to the agent.
+    param 'String[1]', :url
+    param 'String[1]', :runner_name
+    optional_param 'String[1]', :filename
+  end
+
+  def unregister_to_file(url, runner_name, filename = "/etc/gitlab-runner/auth-token-#{runner_name}")
+    return unless File.exist?(filename)
+
+    authtoken = File.read(filename).strip
+    PuppetX::Gitlab::Runner.unregister(url, token: authtoken) unless Puppet.settings[:noop]
+  end
+end

--- a/lib/puppet_x/gitlab/dumper.rb
+++ b/lib/puppet_x/gitlab/dumper.rb
@@ -1,0 +1,142 @@
+# The MIT License (MIT)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# The Dumper class was blindly copied from https://github.com/emancu/toml-rb/blob/v2.0.1/lib/toml-rb/dumper.rb
+# This allows us to use the `to_toml` function as a `Deferred` function because the `toml-rb` gem is usually
+# installed on the agent and the `Deferred` function gets evaluated before the catalog gets applied. This
+# makes it in most scenarios impossible to install the gem before it is used.
+
+require 'date'
+
+module PuppetX
+  module Gitlab
+    class Dumper
+      attr_reader :toml_str
+
+      def initialize(hash)
+        @toml_str = ''
+
+        visit(hash, [])
+      end
+
+      private
+
+      def visit(hash, prefix, extra_brackets = false)
+        simple_pairs, nested_pairs, table_array_pairs = sort_pairs hash
+
+        if prefix.any? && (simple_pairs.any? || hash.empty?)
+          print_prefix prefix, extra_brackets
+        end
+
+        dump_pairs simple_pairs, nested_pairs, table_array_pairs, prefix
+      end
+
+      def sort_pairs(hash)
+        nested_pairs = []
+        simple_pairs = []
+        table_array_pairs = []
+
+        hash.keys.sort.each do |key|
+          val = hash[key]
+          element = [key, val]
+
+          if val.is_a? Hash
+            nested_pairs << element
+          elsif val.is_a?(Array) && val.first.is_a?(Hash)
+            table_array_pairs << element
+          else
+            simple_pairs << element
+          end
+        end
+
+        [simple_pairs, nested_pairs, table_array_pairs]
+      end
+
+      def dump_pairs(simple, nested, table_array, prefix = [])
+        # First add simple pairs, under the prefix
+        dump_simple_pairs simple
+        dump_nested_pairs nested, prefix
+        dump_table_array_pairs table_array, prefix
+      end
+
+      def dump_simple_pairs(simple_pairs)
+        simple_pairs.each do |key, val|
+          key = quote_key(key) unless bare_key? key
+          @toml_str << "#{key} = #{to_toml(val)}\n"
+        end
+      end
+
+      def dump_nested_pairs(nested_pairs, prefix)
+        nested_pairs.each do |key, val|
+          key = quote_key(key) unless bare_key? key
+
+          visit val, prefix + [key], false
+        end
+      end
+
+      def dump_table_array_pairs(table_array_pairs, prefix)
+        table_array_pairs.each do |key, val|
+          key = quote_key(key) unless bare_key? key
+          aux_prefix = prefix + [key]
+
+          val.each do |child|
+            print_prefix aux_prefix, true
+            args = sort_pairs(child) << aux_prefix
+
+            dump_pairs(*args)
+          end
+        end
+      end
+
+      def print_prefix(prefix, extra_brackets = false)
+        new_prefix = prefix.join('.')
+        new_prefix = '[' + new_prefix + ']' if extra_brackets
+
+        @toml_str += "[" + new_prefix + "]\n" # rubocop:disable Style/StringLiterals
+      end
+
+      def to_toml(obj)
+        if obj.is_a?(Time) || obj.is_a?(DateTime)
+          obj.strftime('%Y-%m-%dT%H:%M:%SZ')
+        elsif obj.is_a?(Date)
+          obj.strftime('%Y-%m-%d')
+        elsif obj.is_a? Regexp
+          obj.inspect.inspect
+        elsif obj.is_a? String
+          obj.inspect.gsub(/\\(#[$@{])/, '\1') # rubocop:disable Style/RegexpLiteral
+        else
+          obj.inspect
+        end
+      end
+
+      def bare_key?(key)
+        # rubocop:disable Style/DoubleNegation
+        # rubocop:disable Style/RegexpLiteral
+        !!key.to_s.match(/^[a-zA-Z0-9_-]*$/)
+        # rubocop:enable Style/DoubleNegation
+        # rubocop:enable Style/RegexpLiteral
+      end
+
+      def quote_key(key)
+        '"' + key.gsub('"', '\\"') + '"'
+      end
+    end
+  end
+end

--- a/lib/puppet_x/gitlab/runner.rb
+++ b/lib/puppet_x/gitlab/runner.rb
@@ -1,0 +1,56 @@
+require 'json'
+require 'net/http'
+require 'uri'
+
+module PuppetX
+  module Gitlab
+    module APIClient
+      def self.delete(url, options)
+        response = request(url, Net::HTTP::Delete, options)
+        validate(response)
+
+        {}
+      end
+
+      def self.post(url, options)
+        response = request(url, Net::HTTP::Post, options)
+        validate(response)
+
+        JSON.parse(response.body)
+      end
+
+      def self.request(url, http_method, options)
+        uri     = URI.parse(url)
+        headers = {
+          'Accept'       => 'application/json',
+          'Content-Type' => 'application/json'
+        }
+
+        http = Net::HTTP.new(uri.host, uri.port)
+        if uri.scheme == 'https'
+          http.use_ssl     = true
+          http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        end
+        request          = http_method.new(uri.request_uri, headers)
+        request.body     = options.to_json
+        http.request(request)
+      end
+
+      def self.validate(response)
+        raise Net::HTTPError.new(response.message, response) unless response.code.start_with?('2')
+      end
+    end
+
+    module Runner
+      def self.register(host, options)
+        url = "#{host}/api/v4/runners"
+        PuppetX::Gitlab::APIClient.post(url, options)
+      end
+
+      def self.unregister(host, options)
+        url = "#{host}/api/v4/runners"
+        PuppetX::Gitlab::APIClient.delete(url, options)
+      end
+    end
+  end
+end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -40,6 +40,6 @@ class gitlab_ci_runner::config (
   concat::fragment { "${config_path} - global options":
     target  => $config_path,
     order   => 1,
-    content => inline_template("<%= require 'toml-rb'; TomlRB.dump(@global_options) %>"),
+    content => gitlab_ci_runner::to_toml($global_options),
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 4.1.0 < 7.0.0"
+      "version_requirement": ">= 6.3.0 < 7.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
@@ -72,7 +72,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.8 < 7.0.0"
+      "version_requirement": ">= 6.0.0 < 7.0.0"
     }
   ]
 }

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -7,7 +7,6 @@ describe 'gitlab_ci_runner class' do
       include gitlab_ci_runner
       EOS
 
-      shell('/opt/puppetlabs/puppet/bin/gem install toml-rb')
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
     end

--- a/spec/acceptance/gitlab_ci_runner_spec.rb
+++ b/spec/acceptance/gitlab_ci_runner_spec.rb
@@ -36,7 +36,7 @@ describe 'gitlab_ci_runner class' do
       it { is_expected.to be_enabled }
     end
 
-    xit 'registered the runner' do
+    it 'registered the runner' do
       authtoken = shell("grep 'token = ' /etc/gitlab-runner/config.toml | cut -d '\"' -f2").stdout
       shell("/usr/bin/env curl -X POST --form 'token=#{authtoken}' http://gitlab/api/v4/runners/verify") do |r|
         expect(r.stdout).to eq('"200"')

--- a/spec/acceptance/runner_spec.rb
+++ b/spec/acceptance/runner_spec.rb
@@ -13,7 +13,6 @@ describe 'gitlab_ci_runner::runner define' do
       }
       EOS
 
-      shell('/opt/puppetlabs/puppet/bin/gem install toml-rb')
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
     end

--- a/spec/classes/gitlab_ci_runner_spec.rb
+++ b/spec/classes/gitlab_ci_runner_spec.rb
@@ -7,6 +7,14 @@ describe 'gitlab_ci_runner', type: :class do
 
   on_supported_os.each do |os, facts|
     context "on #{os}" do
+      before do
+        # Make 'gitlab_ci_runner::register_to_file' think that we already have a token on disk
+        # This ensure the function won't call a Gitlab server to try getting the auth token.
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with('/etc/gitlab-runner/auth-token-test_runner').and_return(true)
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with('/etc/gitlab-runner/auth-token-test_runner').and_return('authtoken')
+      end
       let(:facts) do
         facts
       end

--- a/spec/functions/register_spec.rb
+++ b/spec/functions/register_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require 'webmock/rspec'
+
+describe 'gitlab_ci_runner::register' do
+  let(:url) { 'https://gitlab.example.org' }
+  let(:regtoken) { 'registration-token' }
+  let(:return_hash) do
+    {
+      'id' => 1234,
+      'token' => 'auth-token'
+    }
+  end
+
+  it { is_expected.not_to eq(nil) }
+  it { is_expected.to run.with_params.and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params('').and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params('ftp://foooo.bar').and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params('https://gitlab.com', 1234).and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params('https://gitlab.com', 'registration-token', project: 1234).and_raise_error(ArgumentError) }
+
+  it "calls 'PuppetX::Gitlab::Runner.register'" do
+    allow(PuppetX::Gitlab::Runner).to receive(:register).with(url, 'token' => regtoken).and_return(return_hash)
+
+    is_expected.to run.with_params(url, regtoken).and_return(return_hash)
+    expect(PuppetX::Gitlab::Runner).to have_received(:register)
+  end
+
+  it "passes additional args to 'PuppetX::Gitlab::Runner.register'" do
+    allow(PuppetX::Gitlab::Runner).to receive(:register).with(url, 'token' => regtoken, 'active' => false).and_return(return_hash)
+
+    is_expected.to run.with_params(url, regtoken, 'active' => false).and_return(return_hash)
+    expect(PuppetX::Gitlab::Runner).to have_received(:register)
+  end
+end

--- a/spec/functions/register_to_file_spec.rb
+++ b/spec/functions/register_to_file_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+require 'webmock/rspec'
+
+describe 'gitlab_ci_runner::register_to_file' do
+  let(:url) { 'https://gitlab.example.org' }
+  let(:regtoken) { 'registration-token' }
+  let(:runner_name) { 'testrunner' }
+  let(:filename) { "/etc/gitlab-runner/auth-token-#{runner_name}" }
+  let(:return_hash) do
+    {
+      'id' => 1234,
+      'token' => 'auth-token'
+    }
+  end
+
+  it { is_expected.not_to eq(nil) }
+  it { is_expected.to run.with_params.and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params('').and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params('ftp://foooo.bar').and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params('https://gitlab.com', 1234).and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params('https://gitlab.com', 'registration-token', project: 1234).and_raise_error(ArgumentError) }
+
+  context 'uses an existing auth token from file' do
+    before do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with(filename).and_return(true)
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with(filename).and_return(return_hash['token'])
+    end
+
+    it { is_expected.to run.with_params(url, regtoken, runner_name).and_return(return_hash['token']) }
+  end
+
+  context "retrieves from Gitlab and writes auth token to file if it doesn't exist" do
+    before do
+      allow(PuppetX::Gitlab::Runner).to receive(:register).with(url, 'token' => regtoken).and_return(return_hash)
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with(File.dirname(filename)).and_return(true)
+      allow(File).to receive(:write).with(filename, return_hash['token'])
+      allow(File).to receive(:chmod).with(0o400, filename)
+    end
+
+    it { is_expected.to run.with_params(url, regtoken, runner_name).and_return(return_hash['token']) }
+  end
+
+  context 'noop does not register runner and returns dummy token' do
+    before do
+      allow(Puppet.settings).to receive(:[]).and_call_original
+      allow(Puppet.settings).to receive(:[]).with(:noop).and_return(true)
+    end
+
+    it { is_expected.to run.with_params(url, regtoken, runner_name).and_return('DUMMY-NOOP-TOKEN') }
+  end
+end

--- a/spec/functions/to_toml_spec.rb
+++ b/spec/functions/to_toml_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'gitlab_ci_runner::to_toml' do
+  context 'fails on invalid params' do
+    it { is_expected.not_to eq(nil) }
+    [
+      nil,
+      '',
+      'foobar',
+      1,
+      true,
+      false,
+      []
+    ].each do |value|
+      it { is_expected.to run.with_params(value).and_raise_error(ArgumentError) }
+    end
+  end
+
+  context 'returns TOML string on valid params' do
+    it { is_expected.to run.with_params({}).and_return('') }
+    it { is_expected.to run.with_params(foo: 'bar').and_return("foo = \"bar\"\n") }
+    it { is_expected.to run.with_params(foo: { bar: 'baz' }).and_return("[foo]\nbar = \"baz\"\n") }
+    it { is_expected.to run.with_params(foo: %w[bar baz]).and_return("foo = [\"bar\", \"baz\"]\n") }
+    it { is_expected.to run.with_params(foo: [{ bar: {}, baz: {} }]).and_return("[[foo]]\n[foo.bar]\n[foo.baz]\n") }
+  end
+end

--- a/spec/functions/unregister_from_file_spec.rb
+++ b/spec/functions/unregister_from_file_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require 'webmock/rspec'
+
+describe 'gitlab_ci_runner::unregister_from_file' do
+  let(:url) { 'https://gitlab.example.org' }
+  let(:runner_name) { 'testrunner' }
+  let(:filename) { "/etc/gitlab-runner/auth-token-#{runner_name}" }
+
+  it { is_expected.not_to eq(nil) }
+  it { is_expected.to run.with_params.and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params('').and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params('https://gitlab.com', 1234).and_raise_error(ArgumentError) }
+
+  context 'uses an existing auth token from file to unregister the runner' do
+    before do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with(filename).and_return(true)
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with(filename).and_return('authtoken')
+      allow(PuppetX::Gitlab::Runner).to receive(:unregister).with(url, token: 'authtoken').and_return(nil)
+    end
+
+    it { is_expected.to run.with_params(url, runner_name).and_return(nil) }
+  end
+
+  context "does nothing if file doesn't exist" do
+    before do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with(filename).and_return(false)
+    end
+
+    it { is_expected.to run.with_params(url, runner_name).and_return(nil) }
+  end
+end

--- a/spec/functions/unregister_spec.rb
+++ b/spec/functions/unregister_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'webmock/rspec'
+
+describe 'gitlab_ci_runner::unregister' do
+  let(:url) { 'https://gitlab.example.org' }
+  let(:authtoken) { 'registration-token' }
+  let(:return_hash) { { 'status' => 'success' } }
+
+  it { is_expected.not_to eq(nil) }
+  it { is_expected.to run.with_params.and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params('').and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params('ftp://foooo.bar').and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params('https://gitlab.com', 1234).and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params('https://gitlab.com', 'registration-token', project: 1234).and_raise_error(ArgumentError) }
+
+  it "calls 'PuppetX::Gitlab::Runner.unregister'" do
+    allow(PuppetX::Gitlab::Runner).to receive(:unregister).with(url, token: authtoken).and_return(return_hash)
+
+    is_expected.to run.with_params(url, authtoken).and_return(return_hash)
+    expect(PuppetX::Gitlab::Runner).to have_received(:unregister)
+  end
+end

--- a/spec/tasks/register_runner_spec.rb
+++ b/spec/tasks/register_runner_spec.rb
@@ -4,25 +4,26 @@ require_relative '../../tasks/register_runner.rb'
 describe RegisterRunnerTask do
   let(:params) do
     {
-      url: 'https://gitlab.example.org',
-      token: 'abcdef1234'
+      token: 'registrationtoken',
+      url: 'https://gitlab.example.org'
     }
   end
-  let(:task) { described_class.new }
+  let(:described_object) { described_class.new }
 
-  describe 'task' do
+  describe '.task' do
     it 'can register a runner' do
-      stub_request(:post, 'https://gitlab.example.org/api/v4/runners').
-        with(body: { token: 'abcdef1234' }).
-        to_return(body: '{"id": 777, "token": "3bz5wqfDiYBhxoUNuGVu"}')
-      expect(task.task(params)).to eq('id' => 777, 'token' => '3bz5wqfDiYBhxoUNuGVu')
+      allow(PuppetX::Gitlab::Runner).to receive(:register).
+        with('https://gitlab.example.org', token: 'registrationtoken').
+        and_return('id' => 777, 'token' => '3bz5wqfDiYBhxoUNuGVu')
+
+      expect(described_object.task(params)).to eq('id' => 777, 'token' => '3bz5wqfDiYBhxoUNuGVu')
     end
 
     it 'can raise an error' do
       params.merge(token: 'invalid-token')
       stub_request(:post, 'https://gitlab.example.org/api/v4/runners').
         to_return(status: [403, 'Forbidden'])
-      expect { task.task(params) }.to raise_error(TaskHelper::Error, %r{Gitlab runner failed to register: Forbidden})
+      expect { described_object.task(params) }.to raise_error(TaskHelper::Error, %r{Gitlab runner failed to register: Forbidden})
     end
   end
 end

--- a/spec/tasks/unregister_runner_spec.rb
+++ b/spec/tasks/unregister_runner_spec.rb
@@ -8,21 +8,22 @@ describe UnregisterRunnerTask do
       token: 'abcdef1234'
     }
   end
-  let(:task) { described_class.new }
+  let(:described_object) { described_class.new }
 
-  describe 'task' do
+  describe '.task' do
     it 'can unregister a runner' do
-      stub_request(:delete, 'https://gitlab.example.org/api/v4/runners').
-        with(body: { token: 'abcdef1234' }).
-        to_return(body: nil)
-      expect(task.task(params)).to eq(status: 'success')
+      allow(PuppetX::Gitlab::Runner).to receive(:unregister).
+        with('https://gitlab.example.org', token: 'abcdef1234').
+        and_return({})
+
+      expect(described_object.task(params)).to eq(status: 'success')
     end
 
     it 'can raise an error' do
       params.merge(token: 'invalid-token')
       stub_request(:delete, 'https://gitlab.example.org/api/v4/runners').
         to_return(status: [403, 'Forbidden'])
-      expect { task.task(params) }.to raise_error(TaskHelper::Error, %r{Gitlab runner failed to unregister: Forbidden})
+      expect { described_object.task(params) }.to raise_error(TaskHelper::Error, %r{Gitlab runner failed to unregister: Forbidden})
     end
   end
 end

--- a/spec/unit/puppet_x/gitlab/runner_spec.rb
+++ b/spec/unit/puppet_x/gitlab/runner_spec.rb
@@ -1,0 +1,119 @@
+require 'spec_helper'
+require 'webmock/rspec'
+require_relative '../../../../lib/puppet_x/gitlab/runner.rb'
+
+module PuppetX::Gitlab
+  describe APIClient do
+    describe 'self.delete' do
+      it 'returns an empty hash' do
+        stub_request(:delete, 'https://example.org').
+          with(
+            body: '{}',
+            headers: {
+              'Accept' => 'application/json',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Content-Type' => 'application/json',
+              'User-Agent' => 'Ruby'
+            }
+          ).
+          to_return(status: 204, body: '', headers: {})
+
+        expect(described_class.delete('https://example.org', {})).to eq({})
+      end
+
+      it 'raises an exception on non 200 http code' do
+        stub_request(:delete, 'https://example.org').
+          to_return(status: 403)
+
+        expect { described_class.delete('https://example.org', {}) }.to raise_error(Net::HTTPError)
+      end
+    end
+
+    describe 'self.post' do
+      it 'returns a hash' do
+        stub_request(:post, 'https://example.org').
+          with(
+            body: '{}',
+            headers: {
+              'Accept' => 'application/json',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Content-Type' => 'application/json',
+              'User-Agent' => 'Ruby'
+            }
+          ).
+          to_return(status: 201, body: '{ "id": "12345", "token": "6337ff461c94fd3fa32ba3b1ff4125" }', headers: {})
+
+        expect(described_class.post('https://example.org', {})).to eq('id' => '12345', 'token' => '6337ff461c94fd3fa32ba3b1ff4125')
+      end
+
+      it 'raises an exception on non 200 http code' do
+        stub_request(:delete, 'https://example.org').
+          to_return(status: 501)
+
+        expect { described_class.delete('https://example.org', {}) }.to raise_error(Net::HTTPError)
+      end
+    end
+
+    describe 'self.request' do
+      context 'when doing a request' do
+        before do
+          stub_request(:post, 'example.org')
+          described_class.request('http://example.org/', Net::HTTP::Post, {})
+        end
+
+        it 'uses Accept: application/json' do
+          expect(a_request(:post, 'example.org').
+            with(headers: { 'Accept' => 'application/json' })).
+            to have_been_made
+        end
+
+        it 'uses Content: application/json' do
+          expect(a_request(:post, 'example.org').
+            with(headers: { 'Content-Type' => 'application/json' })).
+            to have_been_made
+        end
+      end
+
+      context 'when doing a HTTPS request' do
+        before do
+          stub_request(:post, 'https://example.org/')
+          described_class.request('https://example.org/', Net::HTTP::Post, {})
+        end
+
+        it 'uses SSL if url contains https://' do
+          expect(a_request(:post, 'https://example.org/')).to have_been_made
+        end
+      end
+    end
+  end
+
+  describe Runner do
+    describe 'self.register' do
+      before do
+        PuppetX::Gitlab::APIClient.
+          stub(:post).
+          with('https://gitlab.example.org/api/v4/runners', token: 'registrationtoken').
+          and_return('id' => 1234, 'token' => '1234567890abcd')
+      end
+      let(:response) { described_class.register('https://gitlab.example.org', token: 'registrationtoken') }
+
+      it 'returns a token' do
+        expect(response['token']).to eq('1234567890abcd')
+      end
+    end
+
+    describe 'self.unregister' do
+      before do
+        PuppetX::Gitlab::APIClient.
+          stub(:delete).
+          with('https://gitlab.example.org/api/v4/runners', token: '1234567890abcd').
+          and_return({})
+      end
+      let(:response) { described_class.unregister('https://gitlab.example.org', token: '1234567890abcd') }
+
+      it 'returns an empty hash' do
+        expect(response).to eq({})
+      end
+    end
+  end
+end

--- a/tasks/register_runner.json
+++ b/tasks/register_runner.json
@@ -1,6 +1,9 @@
 {
   "description": "Registers a runner on a Gitlab instance.",
-  "files": ["ruby_task_helper/files/task_helper.rb"],
+  "files": [
+    "ruby_task_helper/files/task_helper.rb",
+    "gitlab_ci_runner/lib/puppet_x/gitlab/runner.rb"
+  ],
   "input_method": "stdin",
   "parameters": {
     "url": {

--- a/tasks/register_runner.rb
+++ b/tasks/register_runner.rb
@@ -1,31 +1,18 @@
 #!/opt/puppetlabs/puppet/bin/ruby
 # frozen_string_literal: true
 
-require 'json'
-require 'net/http'
-require 'uri'
+require_relative '../lib/puppet_x/gitlab/runner.rb'
 require_relative '../../ruby_task_helper/files/task_helper.rb'
 
 class RegisterRunnerTask < TaskHelper
   def task(**kwargs)
-    host    = kwargs[:url]
+    url     = kwargs[:url]
     options = kwargs.reject { |key, _| %i[_task _installdir url].include?(key) }
-    uri     = URI.parse("#{host}/api/v4/runners")
-    headers = {
-      'Accept'       => 'application/json',
-      'Content-Type' => 'application/json'
-    }
 
-    http         = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https')
-    request      = Net::HTTP::Post.new(uri.request_uri, headers)
-    request.body = options.to_json
-    response     = http.request(request)
-
-    if response.is_a?(Net::HTTPSuccess)
-      JSON.parse(response.body)
-    else
-      msg = "Gitlab runner failed to register: #{response.message}"
-      raise TaskHelper::Error.new(msg, 'bolt-plugin/gitlab-ci-runner-register-error')
+    begin
+      PuppetX::Gitlab::Runner.register(url, options)
+    rescue Net::HTTPError => e
+      raise TaskHelper::Error.new("Gitlab runner failed to register: #{e.message}", 'bolt-plugin/gitlab-ci-runner-register-error')
     end
   end
 end

--- a/tasks/unregister_runner.json
+++ b/tasks/unregister_runner.json
@@ -1,6 +1,9 @@
 {
   "description": "Unregisters a runner from a Gitlab instance.",
-  "files": ["ruby_task_helper/files/task_helper.rb"],
+  "files": [
+    "ruby_task_helper/files/task_helper.rb",
+    "gitlab_ci_runner/lib/puppet_x/gitlab/runner.rb"
+  ],
   "input_method": "stdin",
   "parameters": {
     "url": {

--- a/types/register.pp
+++ b/types/register.pp
@@ -1,0 +1,11 @@
+# @summary A struct of all possible additionl options for gitlab_ci_runner::register
+type Gitlab_ci_runner::Register = Struct[{
+  Optional[description]     => String[1],
+  Optional[info]            => Hash[String[1],String[1]],
+  Optional[active]          => Boolean,
+  Optional[locked]          => Boolean,
+  Optional[run_untagged]    => Boolean,
+  Optional[tag_list]        => Array[String[1]],
+  Optional[access_level]    => Enum['not_protected', 'ref_protected'],
+  Optional[maximum_timeout] => Integer,
+}]

--- a/types/register_parameters.pp
+++ b/types/register_parameters.pp
@@ -1,0 +1,2 @@
+# @summary A enum containing a possible keys used for Gitlab runner registrations
+type Gitlab_ci_runner::Register_parameters = Enum['description', 'info', 'active', 'locked', 'run_untagged', 'run-untagged', 'tag_list', 'tag-list', 'access_level', 'access-level', 'maximum_timeout', 'maximum-timeout']


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This reintroduces the possiblty to register a Gitlab Runner by Puppet
without the need of a manual step. This is done by using a "Deferred"
function which does the registration and returns the authentication
token for the configuration.

As Deferred is a >= Puppet 6 functionality this also drops support for
old Puppet versions.

This is the follow-up PR for #75.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
