### PR TITLE
Add runner registration proxy support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,13 @@ jobs:
           bundler-cache: true
       - name: Start gitlab
         run: ./scripts/start-gitlab.sh
+      - name: Start squid
+        run: ./scripts/start-squid.sh
       - name: Run tests
         run: bundle exec rake beaker
         env:
           BEAKER_PUPPET_COLLECTION: ${{ matrix.puppet.collection }}
           BEAKER_setfile: ${{ matrix.setfile.value }}
+      - name: squid logs
+        run: docker logs squid --tail 50
+        if: always()

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -83,6 +83,7 @@ The following parameters are available in the `gitlab_ci_runner` class:
 * [`repo_base_url`](#repo_base_url)
 * [`repo_keyserver`](#repo_keyserver)
 * [`config_path`](#config_path)
+* [`http_proxy`](#http_proxy)
 
 ##### <a name="runners"></a>`runners`
 
@@ -210,6 +211,20 @@ The path to the config file of Gitlab runner.
 
 Default value: `'/etc/gitlab-runner/config.toml'`
 
+##### <a name="http_proxy"></a>`http_proxy`
+
+Data type: `Optional[Stdlib::HTTPUrl]`
+
+An HTTP proxy to use whilst registering runners.
+This setting is only used when registering or unregistering runners and will be used for all runners in the `runners` parameter.
+If you have some runners that need to use a proxy and others that don't, leave `runners` and `http_proxy` unset and declare `gitlab_ci_runnner::runner` resources separately.
+If you do need to use an http proxy, you'll probably also want to configure other aspects of your runners to use it, (eg. setting `http_proxy` environment variables, `pre-clone-script`, `pre-build-script` etc.)
+Exactly how you might need to configure your runners varies between runner executors and specific use-cases.
+This module makes no attempt to automatically alter your runner configurations based on the value of this parameter.
+More information on what you might need to configure can be found [here](https://docs.gitlab.com/runner/configuration/proxy.html)
+
+Default value: ``undef``
+
 ## Defined types
 
 ### <a name="gitlab_ci_runnerrunner"></a>`gitlab_ci_runner::runner`
@@ -285,6 +300,7 @@ The following parameters are available in the `gitlab_ci_runner::runner` defined
 
 * [`config`](#config)
 * [`ensure`](#ensure)
+* [`http_proxy`](#http_proxy)
 
 ##### <a name="config"></a>`config`
 
@@ -303,6 +319,14 @@ Will add/remove the configuration from config.toml
 Will also register/unregister the runner.
 
 Default value: `'present'`
+
+##### <a name="http_proxy"></a>`http_proxy`
+
+Data type: `Optional[Stdlib::HTTPUrl]`
+
+
+
+Default value: ``undef``
 
 ## Functions
 
@@ -373,7 +397,7 @@ gitlab_ci_runner::runner { 'testrunner':
 }
 ```
 
-#### `gitlab_ci_runner::register_to_file(String[1] $url, String[1] $regtoken, String[1] $runner_name, Optional[Hash] $additional_options, Optional[String[1]] $filename)`
+#### `gitlab_ci_runner::register_to_file(String[1] $url, String[1] $regtoken, String[1] $runner_name, Optional[Hash] $additional_options, Optional[Optional[String[1]]] $proxy)`
 
 A function that registers a Gitlab runner on a Gitlab instance, if it doesn't already exist,
 _and_ saves the retrieved authentication token to a file. This is helpful for Deferred functions.
@@ -412,17 +436,17 @@ Data type: `String[1]`
 
 The name of the runner. Use as identifier for the retrieved auth token.
 
-##### `filename`
-
-Data type: `Optional[String[1]]`
-
-The filename where the token should be saved.
-
 ##### `additional_options`
 
 Data type: `Optional[Hash]`
 
 A hash with all additional configuration options for that runner
+
+##### `proxy`
+
+Data type: `Optional[Optional[String[1]]]`
+
+The HTTP proxy to use when registering
 
 ### <a name="gitlab_ci_runnerto_toml"></a>`gitlab_ci_runner::to_toml`
 
@@ -522,7 +546,7 @@ file { '/etc/gitlab-runner/auth-token-testrunner':
 }
 ```
 
-#### `gitlab_ci_runner::unregister_from_file(String[1] $url, String[1] $runner_name, Optional[String[1]] $filename)`
+#### `gitlab_ci_runner::unregister_from_file(String[1] $url, String[1] $runner_name, Optional[Optional[String[1]]] $proxy)`
 
 A function that unregisters a Gitlab runner from a Gitlab instance, if the local token is there.
 This is meant to be used in conjunction with the gitlab_ci_runner::register_to_file function.
@@ -552,11 +576,11 @@ Data type: `String[1]`
 
 The name of the runner. Use as identifier for the retrived auth token.
 
-##### `filename`
+##### `proxy`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[Optional[String[1]]]`
 
-The filename where the token should be saved.
+HTTP proxy to use when unregistering
 
 ## Data types
 

--- a/lib/puppet/functions/gitlab_ci_runner/register_to_file.rb
+++ b/lib/puppet/functions/gitlab_ci_runner/register_to_file.rb
@@ -7,8 +7,8 @@ Puppet::Functions.create_function(:'gitlab_ci_runner::register_to_file') do
   # @param url The url to your Gitlab instance. Please only provide the host part (e.g https://gitlab.com)
   # @param regtoken Registration token.
   # @param runner_name The name of the runner. Use as identifier for the retrieved auth token.
-  # @param filename The filename where the token should be saved.
   # @param additional_options A hash with all additional configuration options for that runner
+  # @param proxy The HTTP proxy to use when registering
   # @return [String] Returns the authentication token
   # @example Using it as a Deferred function
   #   gitlab_ci_runner::runner { 'testrunner':
@@ -25,17 +25,18 @@ Puppet::Functions.create_function(:'gitlab_ci_runner::register_to_file') do
     param 'String[1]', :regtoken
     param 'String[1]', :runner_name
     optional_param 'Hash', :additional_options
-    optional_param 'String[1]', :filename
+    optional_param 'Optional[String[1]]', :proxy
     return_type 'String[1]'
   end
 
-  def register_to_file(url, regtoken, runner_name, additional_options = {}, filename = "/etc/gitlab-runner/auth-token-#{runner_name}")
+  def register_to_file(url, regtoken, runner_name, additional_options = {}, proxy = nil)
+    filename = "/etc/gitlab-runner/auth-token-#{runner_name}"
     if File.exist?(filename)
       authtoken = File.read(filename).strip
     else
       return 'DUMMY-NOOP-TOKEN' if Puppet.settings[:noop]
       begin
-        authtoken = PuppetX::Gitlab::Runner.register(url, additional_options.merge('token' => regtoken))['token']
+        authtoken = PuppetX::Gitlab::Runner.register(url, additional_options.merge('token' => regtoken), proxy)['token']
 
         # If this function is used as a Deferred function the Gitlab Runner config dir
         # will not exist on the first run, because the package isn't installed yet.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,7 +43,14 @@
 #   The keyserver which should be used to get the repository key.
 # @param config_path
 #   The path to the config file of Gitlab runner.
-#
+# @param http_proxy
+#   An HTTP proxy to use whilst registering runners.
+#   This setting is only used when registering or unregistering runners and will be used for all runners in the `runners` parameter.
+#   If you have some runners that need to use a proxy and others that don't, leave `runners` and `http_proxy` unset and declare `gitlab_ci_runnner::runner` resources separately.
+#   If you do need to use an http proxy, you'll probably also want to configure other aspects of your runners to use it, (eg. setting `http_proxy` environment variables, `pre-clone-script`, `pre-build-script` etc.)
+#   Exactly how you might need to configure your runners varies between runner executors and specific use-cases.
+#   This module makes no attempt to automatically alter your runner configurations based on the value of this parameter.
+#   More information on what you might need to configure can be found [here](https://docs.gitlab.com/runner/configuration/proxy.html)
 class gitlab_ci_runner (
   String                                 $xz_package_name, # Defaults in module hieradata
   Hash                                   $runners         = {},
@@ -61,6 +68,7 @@ class gitlab_ci_runner (
   Stdlib::HTTPUrl                        $repo_base_url   = 'https://packages.gitlab.com',
   Optional[Stdlib::Fqdn]                 $repo_keyserver  = undef,
   String                                 $config_path     = '/etc/gitlab-runner/config.toml',
+  Optional[Stdlib::HTTPUrl]              $http_proxy      = undef,
 ) {
   if $manage_docker {
     # workaround for cirunner issue #1617
@@ -100,10 +108,11 @@ class gitlab_ci_runner (
     }
 
     gitlab_ci_runner::runner { $title:
-      ensure  => $_config['ensure'],
-      config  => $_config - ['ensure', 'name'],
-      require => Class['gitlab_ci_runner::config'],
-      notify  => Class['gitlab_ci_runner::service'],
+      ensure     => $_config['ensure'],
+      config     => $_config - ['ensure', 'name'],
+      http_proxy => $http_proxy,
+      require    => Class['gitlab_ci_runner::config'],
+      notify     => Class['gitlab_ci_runner::service'],
     }
   }
 }

--- a/manifests/runner.pp
+++ b/manifests/runner.pp
@@ -68,6 +68,7 @@
 define gitlab_ci_runner::runner (
   Hash $config,
   Enum['present', 'absent'] $ensure = 'present',
+  Optional[Stdlib::HTTPUrl] $http_proxy = undef,
 ) {
   include gitlab_ci_runner
 
@@ -83,7 +84,7 @@ define gitlab_ci_runner::runner (
     .filter |$item| { $item[0] =~ Gitlab_ci_runner::Register_parameters } # Get all items use for the registration process
     .reduce( {}) |$memo, $item| { $memo + { regsubst($item[0], '-', '_', 'G') => $item[1] } } # Ensure all keys use '_' instead of '-'
 
-    $deferred_call = Deferred('gitlab_ci_runner::register_to_file', [$_config['url'], $_config['registration-token'], $_config['name'], $register_additional_options,])
+    $deferred_call = Deferred('gitlab_ci_runner::register_to_file', [$_config['url'], $_config['registration-token'], $_config['name'], $register_additional_options, $http_proxy])
 
     # Remove registration-token and add a 'token' key to the config with a Deferred function to get it.
     $__config = ($_config - (Array(Gitlab_ci_runner::Register_parameters) + 'registration-token')) + { 'token' => $deferred_call }
@@ -110,7 +111,7 @@ define gitlab_ci_runner::runner (
       content => $content,
     }
   } else {
-    $absent_content = Deferred('gitlab_ci_runner::unregister_from_file', [$_config['url'], $_config['name'],])
+    $absent_content = Deferred('gitlab_ci_runner::unregister_from_file',[$_config['url'], $_config['name'], $http_proxy])
 
     file { "/etc/gitlab-runner/auth-token-${_config['name']}":
       ensure  => absent,

--- a/scripts/start-squid.sh
+++ b/scripts/start-squid.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+cat << EOF > /tmp/squid.conf
+http_port 3128
+http_access allow all
+logfile_rotate 0
+cache_log stdio:/dev/stdout
+access_log stdio:/dev/stdout
+cache_store_log stdio:/dev/stdout
+EOF
+
+GITLAB_IP=`cat ~/GITLAB_IP`
+
+docker run --detach --rm \
+  --name squid \
+  --hostname squid \
+  --publish 3128:3128 \
+  --env='SQUID_CONFIG_FILE=/etc/squid/my-squid.conf' \
+  --volume=/tmp/squid.conf:/etc/squid/my-squid.conf:ro \
+  --add-host="gitlab:${GITLAB_IP}" \
+  b4tman/squid
+
+sleep 3
+docker logs squid --tail 100
+
+docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' squid > ~/SQUID_IP

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -26,15 +26,14 @@ describe 'gitlab_ci_runner class' do
   end
 
   context 'concurrent => 20' do
-    it 'idempotently with no errors' do
-      pp = <<-EOS
-      class { 'gitlab_ci_runner':
-        concurrent => 20,
-      }
-      EOS
-
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-EOS
+        class { 'gitlab_ci_runner':
+          concurrent => 20,
+        }
+        EOS
+      end
     end
 
     describe file('/etc/gitlab-runner/config.toml') do
@@ -43,15 +42,14 @@ describe 'gitlab_ci_runner class' do
   end
 
   context 'log_level => error' do
-    it 'idempotently with no errors' do
-      pp = <<-EOS
-      class { 'gitlab_ci_runner':
-        log_level => 'error',
-      }
-      EOS
-
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-EOS
+        class { 'gitlab_ci_runner':
+          log_level => 'error',
+        }
+        EOS
+      end
     end
 
     describe file('/etc/gitlab-runner/config.toml') do
@@ -60,15 +58,14 @@ describe 'gitlab_ci_runner class' do
   end
 
   context 'log_format => text' do
-    it 'idempotently with no errors' do
-      pp = <<-EOS
-      class { 'gitlab_ci_runner':
-        log_format => 'text',
-      }
-      EOS
-
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-EOS
+        class { 'gitlab_ci_runner':
+          log_format => 'text',
+        }
+        EOS
+      end
     end
 
     describe file('/etc/gitlab-runner/config.toml') do
@@ -77,15 +74,14 @@ describe 'gitlab_ci_runner class' do
   end
 
   context 'check_interval => 42' do
-    it 'idempotently with no errors' do
-      pp = <<-EOS
-      class { 'gitlab_ci_runner':
-        check_interval => 42,
-      }
-      EOS
-
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-EOS
+        class { 'gitlab_ci_runner':
+          check_interval => 42,
+        }
+        EOS
+      end
     end
 
     describe file('/etc/gitlab-runner/config.toml') do
@@ -94,15 +90,14 @@ describe 'gitlab_ci_runner class' do
   end
 
   context 'sentry_dsn => https://123abc@localhost/1' do
-    it 'idempotently with no errors' do
-      pp = <<-EOS
-      class { 'gitlab_ci_runner':
-        sentry_dsn => 'https://123abc@localhost/1',
-      }
-      EOS
-
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-EOS
+        class { 'gitlab_ci_runner':
+          sentry_dsn => 'https://123abc@localhost/1',
+        }
+        EOS
+      end
     end
 
     describe file('/etc/gitlab-runner/config.toml') do
@@ -111,15 +106,14 @@ describe 'gitlab_ci_runner class' do
   end
 
   context 'listen_address => localhost:9252' do
-    it 'idempotently with no errors' do
-      pp = <<-EOS
-      class { 'gitlab_ci_runner':
-        listen_address => 'localhost:9252',
-      }
-      EOS
-
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-EOS
+        class { 'gitlab_ci_runner':
+          listen_address => 'localhost:9252',
+        }
+        EOS
+      end
     end
 
     describe file('/etc/gitlab-runner/config.toml') do

--- a/spec/acceptance/gitlab_ci_runner_spec.rb
+++ b/spec/acceptance/gitlab_ci_runner_spec.rb
@@ -82,4 +82,42 @@ describe 'gitlab_ci_runner class' do
       end
     end
   end
+
+  context 'using proxy parameters' do
+    it 'idempotently with no errors' do
+      pp = <<-EOS
+      class { 'gitlab_ci_runner':
+        http_proxy      => 'http://squid:3128',
+        manage_docker   => false,
+        runners         => {
+          test_runner => {}
+        },
+        runner_defaults => {
+          url                => 'http://gitlab',
+          registration-token => '#{registrationtoken}',
+          executor           => 'shell',
+        }
+      }
+      EOS
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe package('gitlab-runner') do
+      it { is_expected.to be_installed }
+    end
+
+    describe service('gitlab-runner') do
+      it { is_expected.to be_running }
+      it { is_expected.to be_enabled }
+    end
+
+    it 'registered the runner' do
+      authtoken = shell("grep 'token = ' /etc/gitlab-runner/config.toml | cut -d '\"' -f2").stdout
+      shell("/usr/bin/env curl -X POST --form 'token=#{authtoken}' http://gitlab/api/v4/runners/verify") do |r|
+        expect(r.stdout).to eq('"200"')
+      end
+    end
+  end
 end

--- a/spec/acceptance/gitlab_ci_runner_spec.rb
+++ b/spec/acceptance/gitlab_ci_runner_spec.rb
@@ -9,23 +9,22 @@ describe 'gitlab_ci_runner class' do
 
   authtoken = nil
   context 'default parameters' do
-    it 'idempotently with no errors' do
-      pp = <<-EOS
-      class { 'gitlab_ci_runner':
-        manage_docker   => false,
-        runners         => {
-          test_runner => {}
-        },
-        runner_defaults => {
-          url                => 'http://gitlab',
-          registration-token => '#{registrationtoken}',
-          executor           => 'shell',
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-EOS
+        class { 'gitlab_ci_runner':
+          manage_docker   => false,
+          runners         => {
+            test_runner => {}
+          },
+          runner_defaults => {
+            url                => 'http://gitlab',
+            registration-token => '#{registrationtoken}',
+            executor           => 'shell',
+          }
         }
-      }
-      EOS
-
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
+        EOS
+      end
     end
 
     describe package('gitlab-runner') do
@@ -37,34 +36,35 @@ describe 'gitlab_ci_runner class' do
       it { is_expected.to be_enabled }
     end
 
-    it 'registered the runner' do
-      authtoken = shell("grep 'token = ' /etc/gitlab-runner/config.toml | cut -d '\"' -f2").stdout
-      shell("/usr/bin/env curl -X POST --form 'token=#{authtoken}' http://gitlab/api/v4/runners/verify") do |r|
-        expect(r.stdout).to eq('"200"')
+    describe 'registration' do
+      it 'registered the runner' do
+        authtoken = shell("grep 'token = ' /etc/gitlab-runner/config.toml | cut -d '\"' -f2").stdout
+        shell("/usr/bin/env curl -X POST --form 'token=#{authtoken}' http://gitlab/api/v4/runners/verify") do |r|
+          expect(r.stdout).to eq('"200"')
+        end
       end
     end
   end
 
   context 'unregistering' do
-    it 'idempotently with no errors' do
-      pp = <<-EOS
-      class { 'gitlab_ci_runner':
-        manage_docker   => false,
-        runners         => {
-          test_runner => {
-            ensure => absent,
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-EOS
+        class { 'gitlab_ci_runner':
+          manage_docker   => false,
+          runners         => {
+            test_runner => {
+              ensure => absent,
+            }
+          },
+          runner_defaults => {
+            url                => 'http://gitlab',
+            registration-token => '#{registrationtoken}',
+            executor           => 'shell',
           }
-        },
-        runner_defaults => {
-          url                => 'http://gitlab',
-          registration-token => '#{registrationtoken}',
-          executor           => 'shell',
         }
-      }
-      EOS
-
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
+        EOS
+      end
     end
 
     describe package('gitlab-runner') do
@@ -76,32 +76,33 @@ describe 'gitlab_ci_runner class' do
       it { is_expected.to be_enabled }
     end
 
-    it 'unregistered the runner' do
-      shell("/usr/bin/env curl -X POST --form 'token=#{authtoken}' http://gitlab/api/v4/runners/verify") do |r|
-        expect(r.stdout).not_to eq('"200"')
+    describe 'registration' do
+      it 'unregistered the runner' do
+        shell("/usr/bin/env curl -X POST --form 'token=#{authtoken}' http://gitlab/api/v4/runners/verify") do |r|
+          expect(r.stdout).not_to eq('"200"')
+        end
       end
     end
   end
 
   context 'using proxy parameters' do
-    it 'idempotently with no errors' do
-      pp = <<-EOS
-      class { 'gitlab_ci_runner':
-        http_proxy      => 'http://squid:3128',
-        manage_docker   => false,
-        runners         => {
-          test_runner => {}
-        },
-        runner_defaults => {
-          url                => 'http://gitlab',
-          registration-token => '#{registrationtoken}',
-          executor           => 'shell',
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-EOS
+        class { 'gitlab_ci_runner':
+          http_proxy      => 'http://squid:3128',
+          manage_docker   => false,
+          runners         => {
+            test_runner => {}
+          },
+          runner_defaults => {
+            url                => 'http://gitlab',
+            registration-token => '#{registrationtoken}',
+            executor           => 'shell',
+          }
         }
-      }
-      EOS
-
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
+        EOS
+      end
     end
 
     describe package('gitlab-runner') do
@@ -113,10 +114,12 @@ describe 'gitlab_ci_runner class' do
       it { is_expected.to be_enabled }
     end
 
-    it 'registered the runner' do
-      authtoken = shell("grep 'token = ' /etc/gitlab-runner/config.toml | cut -d '\"' -f2").stdout
-      shell("/usr/bin/env curl -X POST --form 'token=#{authtoken}' http://gitlab/api/v4/runners/verify") do |r|
-        expect(r.stdout).to eq('"200"')
+    describe 'registration' do
+      it 'registered the runner' do
+        authtoken = shell("grep 'token = ' /etc/gitlab-runner/config.toml | cut -d '\"' -f2").stdout
+        shell("/usr/bin/env curl -X POST --form 'token=#{authtoken}' http://gitlab/api/v4/runners/verify") do |r|
+          expect(r.stdout).to eq('"200"')
+        end
       end
     end
   end

--- a/spec/acceptance/runner_spec.rb
+++ b/spec/acceptance/runner_spec.rb
@@ -2,19 +2,18 @@ require 'spec_helper_acceptance'
 
 describe 'gitlab_ci_runner::runner define' do
   context 'simple runner' do
-    it 'idempotently with no errors' do
-      pp = <<-EOS
-      gitlab_ci_runner::runner { 'testrunner':
-        config => {
-          'url'      => 'https://gitlab.com',
-          'token'    => '123456789abcdefgh',
-          'executor' => 'shell',
-        },
-      }
-      EOS
-
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-EOS
+        gitlab_ci_runner::runner { 'testrunner':
+          config => {
+            'url'      => 'https://gitlab.com',
+            'token'    => '123456789abcdefgh',
+            'executor' => 'shell',
+          },
+        }
+        EOS
+      end
     end
 
     describe package('gitlab-runner') do
@@ -36,56 +35,55 @@ describe 'gitlab_ci_runner::runner define' do
   end
 
   context 'autoscaling runner with DigitalOcean as IaaS' do
-    it 'idempotently with no errors' do
-      pp = <<-EOS
-      gitlab_ci_runner::runner { 'autoscale-runner':
-        config => {
-         url      => 'https://gitlab.com',
-         token    => '123456789abcdefgh',
-         name     => 'autoscale-runner',
-         executor => 'docker+machine',
-         limit    => 10,
-         docker   => {
-           image => 'ruby:2.6',
-         },
-         machine  => {
-           'OffPeakPeriods'   => [
-             '* * 0-9,18-23 * * mon-fri *',
-             '* * * * * sat,sun *',
-           ],
-           'OffPeakIdleCount' => 1,
-           'OffPeakIdleTime'  => 1200,
-           'IdleCount'        => 5,
-           'IdleTime'         => 600,
-           'MaxBuilds'        => 100,
-           'MachineName'      => 'auto-scale-%s',
-           'MachineDriver'    => 'digitalocean',
-           'MachineOptions'   => [
-             'digitalocean-image=coreos-stable',
-             'digitalocean-ssh-user=core',
-             'digitalocean-access-token=DO_ACCESS_TOKEN',
-             'digitalocean-region=nyc2',
-             'digitalocean-size=4gb',
-             'digitalocean-private-networking',
-             'engine-registry-mirror=http://10.11.12.13:12345',
-           ],
-         },
-         cache    => {
-           'Type' => 's3',
-           s3     => {
-             'ServerAddress' => 's3-eu-west-1.amazonaws.com',
-             'AccessKey'     => 'AMAZON_S3_ACCESS_KEY',
-             'SecretKey'     => 'AMAZON_S3_SECRET_KEY',
-             'BucketName'    => 'runner',
-             'Insecure'      => false,
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-EOS
+        gitlab_ci_runner::runner { 'autoscale-runner':
+          config => {
+           url      => 'https://gitlab.com',
+           token    => '123456789abcdefgh',
+           name     => 'autoscale-runner',
+           executor => 'docker+machine',
+           limit    => 10,
+           docker   => {
+             image => 'ruby:2.6',
            },
-         },
-        },
-      }
-      EOS
-
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
+           machine  => {
+             'OffPeakPeriods'   => [
+               '* * 0-9,18-23 * * mon-fri *',
+               '* * * * * sat,sun *',
+             ],
+             'OffPeakIdleCount' => 1,
+             'OffPeakIdleTime'  => 1200,
+             'IdleCount'        => 5,
+             'IdleTime'         => 600,
+             'MaxBuilds'        => 100,
+             'MachineName'      => 'auto-scale-%s',
+             'MachineDriver'    => 'digitalocean',
+             'MachineOptions'   => [
+               'digitalocean-image=coreos-stable',
+               'digitalocean-ssh-user=core',
+               'digitalocean-access-token=DO_ACCESS_TOKEN',
+               'digitalocean-region=nyc2',
+               'digitalocean-size=4gb',
+               'digitalocean-private-networking',
+               'engine-registry-mirror=http://10.11.12.13:12345',
+             ],
+           },
+           cache    => {
+             'Type' => 's3',
+             s3     => {
+               'ServerAddress' => 's3-eu-west-1.amazonaws.com',
+               'AccessKey'     => 'AMAZON_S3_ACCESS_KEY',
+               'SecretKey'     => 'AMAZON_S3_SECRET_KEY',
+               'BucketName'    => 'runner',
+               'Insecure'      => false,
+             },
+           },
+          },
+        }
+        EOS
+      end
     end
 
     describe package('gitlab-runner') do

--- a/spec/functions/register_to_file_spec.rb
+++ b/spec/functions/register_to_file_spec.rb
@@ -33,7 +33,7 @@ describe 'gitlab_ci_runner::register_to_file' do
 
   context "retrieves from Gitlab and writes auth token to file if it doesn't exist" do
     before do
-      allow(PuppetX::Gitlab::Runner).to receive(:register).with(url, 'token' => regtoken).and_return(return_hash)
+      allow(PuppetX::Gitlab::Runner).to receive(:register).with(url, { 'token' => regtoken }, nil).and_return(return_hash)
       allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:exist?).with(File.dirname(filename)).and_return(true)
       allow(File).to receive(:write).with(filename, return_hash['token'])

--- a/spec/functions/unregister_from_file_spec.rb
+++ b/spec/functions/unregister_from_file_spec.rb
@@ -17,7 +17,7 @@ describe 'gitlab_ci_runner::unregister_from_file' do
       allow(File).to receive(:exist?).with(filename).and_return(true)
       allow(File).to receive(:read).and_call_original
       allow(File).to receive(:read).with(filename).and_return('authtoken')
-      allow(PuppetX::Gitlab::Runner).to receive(:unregister).with(url, token: 'authtoken').and_return(nil)
+      allow(PuppetX::Gitlab::Runner).to receive(:unregister).with(url, { token: 'authtoken' }, nil).and_return(nil)
     end
 
     it { is_expected.to run.with_params(url, runner_name).and_return('Successfully unregistered gitlab runner testrunner') }

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -46,3 +46,7 @@ file_line { '/etc/hosts-gitlab':
   path => '/etc/hosts',
   line => "${facts['gitlab_ip']} gitlab",
 }
+file_line { '/etc/hosts-squid':
+  path => '/etc/hosts',
+  line => "${facts['squid_ip']} squid",
+}

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,6 +1,7 @@
 require 'voxpupuli/acceptance/spec_helper_acceptance'
 
 ENV['BEAKER_FACTER_GITLAB_IP'] = File.read(File.expand_path('~/GITLAB_IP')).chomp
+ENV['BEAKER_FACTER_SQUID_IP'] = File.read(File.expand_path('~/SQUID_IP')).chomp
 
 configure_beaker do |host|
   install_module_from_forge_on(host, 'puppetlabs/docker', '>= 0')

--- a/spec/unit/puppet_x/gitlab/runner_spec.rb
+++ b/spec/unit/puppet_x/gitlab/runner_spec.rb
@@ -18,14 +18,14 @@ module PuppetX::Gitlab
           ).
           to_return(status: 204, body: '', headers: {})
 
-        expect(described_class.delete('https://example.org', {})).to eq({})
+        expect(described_class.delete('https://example.org', {}, nil)).to eq({})
       end
 
       it 'raises an exception on non 200 http code' do
         stub_request(:delete, 'https://example.org').
           to_return(status: 403)
 
-        expect { described_class.delete('https://example.org', {}) }.to raise_error(Net::HTTPError)
+        expect { described_class.delete('https://example.org', {}, nil) }.to raise_error(Net::HTTPError)
       end
     end
 
@@ -43,14 +43,14 @@ module PuppetX::Gitlab
           ).
           to_return(status: 201, body: '{ "id": "12345", "token": "6337ff461c94fd3fa32ba3b1ff4125" }', headers: {})
 
-        expect(described_class.post('https://example.org', {})).to eq('id' => '12345', 'token' => '6337ff461c94fd3fa32ba3b1ff4125')
+        expect(described_class.post('https://example.org', {}, nil)).to eq('id' => '12345', 'token' => '6337ff461c94fd3fa32ba3b1ff4125')
       end
 
       it 'raises an exception on non 200 http code' do
         stub_request(:delete, 'https://example.org').
           to_return(status: 501)
 
-        expect { described_class.delete('https://example.org', {}) }.to raise_error(Net::HTTPError)
+        expect { described_class.delete('https://example.org', {}, nil) }.to raise_error(Net::HTTPError)
       end
     end
 
@@ -58,7 +58,7 @@ module PuppetX::Gitlab
       context 'when doing a request' do
         before do
           stub_request(:post, 'example.org')
-          described_class.request('http://example.org/', Net::HTTP::Post, {})
+          described_class.request('http://example.org/', Net::HTTP::Post, {}, nil)
         end
 
         it 'uses Accept: application/json' do
@@ -77,7 +77,7 @@ module PuppetX::Gitlab
       context 'when doing a HTTPS request' do
         before do
           stub_request(:post, 'https://example.org/')
-          described_class.request('https://example.org/', Net::HTTP::Post, {})
+          described_class.request('https://example.org/', Net::HTTP::Post, {}, nil)
         end
 
         it 'uses SSL if url contains https://' do
@@ -92,10 +92,10 @@ module PuppetX::Gitlab
       before do
         PuppetX::Gitlab::APIClient.
           stub(:post).
-          with('https://gitlab.example.org/api/v4/runners', token: 'registrationtoken').
+          with('https://gitlab.example.org/api/v4/runners', { token: 'registrationtoken' }, nil).
           and_return('id' => 1234, 'token' => '1234567890abcd')
       end
-      let(:response) { described_class.register('https://gitlab.example.org', token: 'registrationtoken') }
+      let(:response) { described_class.register('https://gitlab.example.org', { token: 'registrationtoken' }, nil) }
 
       it 'returns a token' do
         expect(response['token']).to eq('1234567890abcd')
@@ -106,10 +106,10 @@ module PuppetX::Gitlab
       before do
         PuppetX::Gitlab::APIClient.
           stub(:delete).
-          with('https://gitlab.example.org/api/v4/runners', token: '1234567890abcd').
+          with('https://gitlab.example.org/api/v4/runners', { token: '1234567890abcd' }, nil).
           and_return({})
       end
-      let(:response) { described_class.unregister('https://gitlab.example.org', token: '1234567890abcd') }
+      let(:response) { described_class.unregister('https://gitlab.example.org', { token: '1234567890abcd' }, nil) }
 
       it 'returns an empty hash' do
         expect(response).to eq({})


### PR DESCRIPTION
A new `http_proxy` parameter can be set if you haven't got direct Internet access and need to use a proxy whilst registering runners with gitlab.  It is still the user's responsibility to configure other aspects of their runners to work with a proxy as needed.