### PR TITLE
Fix unregistering runner with `ensure => absent`

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -100,6 +100,7 @@ class gitlab_ci_runner (
     }
 
     gitlab_ci_runner::runner { $title:
+      ensure  => $_config['ensure'],
       config  => $_config - ['ensure', 'name'],
       require => Class['gitlab_ci_runner::config'],
       notify  => Class['gitlab_ci_runner::service'],

--- a/spec/classes/gitlab_ci_runner_spec.rb
+++ b/spec/classes/gitlab_ci_runner_spec.rb
@@ -65,6 +65,32 @@ describe 'gitlab_ci_runner', type: :class do
           )
       end
 
+      describe 'runner ensure' do
+        before do
+          allow(File).to receive(:exist?).and_call_original
+          allow(File).to receive(:read).and_call_original
+          allow(File).to receive(:exist?).with('/etc/gitlab-runner/auth-token-runner_with_ensure_present').and_return(true)
+          allow(File).to receive(:read).with('/etc/gitlab-runner/auth-token-runner_with_ensure_present').and_return('authtoken')
+          allow(File).to receive(:exist?).with('/etc/gitlab-runner/auth-token-runner_with_ensure_absent').and_return(false)
+        end
+        let(:params) do
+          {
+            runner_defaults: {
+              'url' => 'https://git.example.com/ci',
+              'registration-token' => '1234567890abcdef',
+              'executor' => 'shell'
+            },
+            runners: {
+              'runner_with_ensure_absent' => { 'ensure' => 'absent' },
+              'runner_with_ensure_present' => { 'ensure' => 'present' },
+            }
+          }
+        end
+
+        it { is_expected.to contain_gitlab_ci_runner__runner('runner_with_ensure_present').with_ensure('present') }
+        it { is_expected.to contain_gitlab_ci_runner__runner('runner_with_ensure_absent').with_ensure('absent') }
+      end
+
       context 'with concurrent => 10' do
         let(:params) do
           {


### PR DESCRIPTION
The [README ](https://github.com/voxpupuli/puppet-gitlab_ci_runner/tree/735708a02cc7810d76a4e394bdfb752ff639563d#usage)says this should work, and now it does! :)