### PR TITLE
Update module dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,15 +14,15 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 6.3.0 < 7.0.0"
+      "version_requirement": ">= 6.3.0 < 8.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.0 < 7.0.0"
+      "version_requirement": ">= 4.25.0 < 8.0.0"
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 6.3.0 < 8.0.0"
+      "version_requirement": ">= 6.3.0 < 9.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Allow latest versions of `concat`, `stdlib` and `apt`.

Bump the minimum version of `stdlib` to `4.25.0` (where `Stdlib::Fqdn`
was introduced)