### PR TITLE
Fix broken apt::source declaration for Debian-based systems

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -16,6 +16,7 @@ class gitlab_ci_runner::repo (
         repos    => 'main',
         key      => {
           'id'     => 'F6403F6544A38863DAA0B6E03F01618A51312F3F',
+          'source' => 'https://packages.gitlab.com/gpg.key',
           'server' => $repo_keyserver,
         },
         include  => {


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds Gitlab's Apt sigining key directly from the source instead of relying on keyserver.ubuntu.com (which currently doesn't seem to provide the key when running
`/usr/bin/apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F6403F6544A38863DAA0B6E03F01618A51312F3F`
which is what this module attempts to do on Debian-based systems.).

#### This Pull Request (PR) fixes the following issues
Fixes #128 