### PR TITLE
add parameter to specify a ca certificate used to (un)register

### DIFF
--- a/lib/puppet/functions/gitlab_ci_runner/register.rb
+++ b/lib/puppet/functions/gitlab_ci_runner/register.rb
@@ -5,6 +5,7 @@ Puppet::Functions.create_function(:'gitlab_ci_runner::register') do
   # @param url The url to your Gitlab instance. Please only provide the host part (e.g https://gitlab.com)
   # @param token Registration token.
   # @param additional_options A hash with all additional configuration options for that runner
+  # @param ca_file An absolute path to a trusted certificate authority file.
   # @return [Struct[{ id => Integer[1], token => String[1], }]] Returns a hash with the runner id and authentcation token
   # @example Using it as a replacement for the Bolt 'register_runner' task
   #   puppet apply -e "notice(gitlab_ci_runner::register('https://gitlab.com', 'registration-token'))"
@@ -13,11 +14,12 @@ Puppet::Functions.create_function(:'gitlab_ci_runner::register') do
     param 'Stdlib::HTTPUrl', :url
     param 'String[1]', :token
     optional_param 'Gitlab_ci_runner::Register', :additional_options
+    optional_param 'Optional[Stdlib::Absolutepath]', :ca_file
     return_type 'Struct[{ id => Integer[1], token => String[1], }]'
   end
 
-  def register(url, token, additional_options = {})
-    PuppetX::Gitlab::Runner.register(url, additional_options.merge('token' => token))
+  def register(url, token, additional_options = {}, ca_file = nil)
+    PuppetX::Gitlab::Runner.register(url, additional_options.merge('token' => token), ca_file: ca_file)
   rescue Net::HTTPError => e
     raise "Gitlab runner failed to register: #{e.message}"
   end

--- a/lib/puppet/functions/gitlab_ci_runner/unregister.rb
+++ b/lib/puppet/functions/gitlab_ci_runner/unregister.rb
@@ -5,6 +5,7 @@ Puppet::Functions.create_function(:'gitlab_ci_runner::unregister') do
   # @summary A function that unregisters a Gitlab runner from a Gitlab instance. Be careful, this will be triggered on noop runs as well!
   # @param url The url to your Gitlab instance. Please only provide the host part (e.g https://gitlab.com)
   # @param token Runners authentication token.
+  # @param ca_file An absolute path to a trusted certificate authority file.
   # @return [Struct[{ id => Integer[1], token => String[1], }]] Returns a hash with the runner id and authentcation token
   # @example Using it as a replacement for the Bolt 'unregister_runner' task
   #   puppet apply -e "notice(gitlab_ci_runner::unregister('https://gitlab.com', 'runner-auth-token'))"
@@ -12,11 +13,12 @@ Puppet::Functions.create_function(:'gitlab_ci_runner::unregister') do
   dispatch :unregister do
     param 'Stdlib::HTTPUrl', :url
     param 'String[1]', :token
+    optional_param 'Optional[Stdlib::Absolutepath]', :ca_file
     return_type "Struct[{ status => Enum['success'], }]"
   end
 
-  def unregister(url, token)
-    PuppetX::Gitlab::Runner.unregister(url, token: token)
+  def unregister(url, token, ca_file = nil)
+    PuppetX::Gitlab::Runner.unregister(url, { 'token' => token }, ca_file: ca_file)
     { 'status' => 'success' }
   rescue Net::HTTPError => e
     raise "Gitlab runner failed to unregister: #{e.message}"

--- a/lib/puppet/functions/gitlab_ci_runner/unregister_from_file.rb
+++ b/lib/puppet/functions/gitlab_ci_runner/unregister_from_file.rb
@@ -6,6 +6,7 @@ Puppet::Functions.create_function(:'gitlab_ci_runner::unregister_from_file') do
   # @param url The url to your Gitlab instance. Please only provide the host part (e.g https://gitlab.com)
   # @param runner_name The name of the runner. Use as identifier for the retrived auth token.
   # @param proxy HTTP proxy to use when unregistering
+  # @param ca_file An absolute path to a trusted certificate authority file.
   # @example Using it as a Deferred function with a file resource
   #   file { '/etc/gitlab-runner/auth-token-testrunner':
   #     file    => absent,
@@ -17,9 +18,10 @@ Puppet::Functions.create_function(:'gitlab_ci_runner::unregister_from_file') do
     param 'String[1]', :url
     param 'String[1]', :runner_name
     optional_param 'Optional[String[1]]', :proxy
+    optional_param 'Optional[Stdlib::Absolutepath]', :ca_file
   end
 
-  def unregister_from_file(url, runner_name, proxy = nil)
+  def unregister_from_file(url, runner_name, proxy = nil, ca_file = nil)
     filename = "/etc/gitlab-runner/auth-token-#{runner_name}"
     return "#{filename} file doesn't exist" unless File.exist?(filename)
 
@@ -30,7 +32,7 @@ Puppet::Functions.create_function(:'gitlab_ci_runner::unregister_from_file') do
       message
     else
       begin
-        PuppetX::Gitlab::Runner.unregister(url, { token: authtoken }, proxy)
+        PuppetX::Gitlab::Runner.unregister(url, { 'token' => authtoken }, proxy, ca_file)
         message = "Successfully unregistered gitlab runner #{runner_name}"
         Puppet.debug message
         message

--- a/lib/puppet_x/gitlab/runner.rb
+++ b/lib/puppet_x/gitlab/runner.rb
@@ -5,21 +5,21 @@ require 'uri'
 module PuppetX
   module Gitlab
     module APIClient
-      def self.delete(url, options, proxy)
-        response = request(url, Net::HTTP::Delete, options, proxy)
+      def self.delete(url, options, proxy, ca_file)
+        response = request(url, Net::HTTP::Delete, options, proxy, ca_file)
         validate(response)
 
         {}
       end
 
-      def self.post(url, options, proxy)
-        response = request(url, Net::HTTP::Post, options, proxy)
+      def self.post(url, options, proxy, ca_file)
+        response = request(url, Net::HTTP::Post, options, proxy, ca_file)
         validate(response)
 
         JSON.parse(response.body)
       end
 
-      def self.request(url, http_method, options, proxy)
+      def self.request(url, http_method, options, proxy, ca_file)
         uri     = URI.parse(url)
         headers = {
           'Accept'       => 'application/json',
@@ -38,6 +38,7 @@ module PuppetX
         if uri.scheme == 'https'
           http.use_ssl     = true
           http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+          http.ca_file = ca_file if ca_file
         end
         request          = http_method.new(uri.request_uri, headers)
         request.body     = options.to_json
@@ -50,14 +51,14 @@ module PuppetX
     end
 
     module Runner
-      def self.register(host, options, proxy = nil)
+      def self.register(host, options, proxy = nil, ca_file = nil)
         url = "#{host}/api/v4/runners"
-        PuppetX::Gitlab::APIClient.post(url, options, proxy)
+        PuppetX::Gitlab::APIClient.post(url, options, proxy, ca_file)
       end
 
-      def self.unregister(host, options, proxy = nil)
+      def self.unregister(host, options, proxy = nil, ca_file = nil)
         url = "#{host}/api/v4/runners"
-        PuppetX::Gitlab::APIClient.delete(url, options, proxy)
+        PuppetX::Gitlab::APIClient.delete(url, options, proxy, ca_file)
       end
     end
   end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,6 +51,13 @@
 #   Exactly how you might need to configure your runners varies between runner executors and specific use-cases.
 #   This module makes no attempt to automatically alter your runner configurations based on the value of this parameter.
 #   More information on what you might need to configure can be found [here](https://docs.gitlab.com/runner/configuration/proxy.html)
+# @param ca_file
+#   A file containing public keys of trusted certificate authority's in PEM format. 
+#   This setting can be used when the certificate of the gitlab server is signed using a CA
+#   and when upon registering a runner the following error is shown:
+#   certificate verify failed (self signed certificate in certificate chain)
+#   Using the CA file solves https://github.com/voxpupuli/puppet-gitlab_ci_runner/issues/124.
+#
 class gitlab_ci_runner (
   String                                 $xz_package_name, # Defaults in module hieradata
   Hash                                   $runners         = {},
@@ -69,6 +76,7 @@ class gitlab_ci_runner (
   Optional[Gitlab_ci_runner::Keyserver]  $repo_keyserver   = undef,
   String                                 $config_path     = '/etc/gitlab-runner/config.toml',
   Optional[Stdlib::HTTPUrl]              $http_proxy      = undef,
+  Optional[String]                       $ca_file         = undef,
 ) {
   if $manage_docker {
     # workaround for cirunner issue #1617
@@ -111,6 +119,7 @@ class gitlab_ci_runner (
       ensure     => $_config['ensure'],
       config     => $_config - ['ensure', 'name'],
       http_proxy => $http_proxy,
+      ca_file => $ca_file,
       require    => Class['gitlab_ci_runner::config'],
       notify     => Class['gitlab_ci_runner::service'],
     }

--- a/spec/functions/register_spec.rb
+++ b/spec/functions/register_spec.rb
@@ -19,14 +19,14 @@ describe 'gitlab_ci_runner::register' do
   it { is_expected.to run.with_params('https://gitlab.com', 'registration-token', project: 1234).and_raise_error(ArgumentError) }
 
   it "calls 'PuppetX::Gitlab::Runner.register'" do
-    allow(PuppetX::Gitlab::Runner).to receive(:register).with(url, 'token' => regtoken).and_return(return_hash)
+    allow(PuppetX::Gitlab::Runner).to receive(:register).with(url, { 'token' => regtoken }, ca_file: nil).and_return(return_hash)
 
     is_expected.to run.with_params(url, regtoken).and_return(return_hash)
     expect(PuppetX::Gitlab::Runner).to have_received(:register)
   end
 
   it "passes additional args to 'PuppetX::Gitlab::Runner.register'" do
-    allow(PuppetX::Gitlab::Runner).to receive(:register).with(url, 'token' => regtoken, 'active' => false).and_return(return_hash)
+    allow(PuppetX::Gitlab::Runner).to receive(:register).with(url, { 'token' => regtoken, 'active' => false }, ca_file: nil).and_return(return_hash)
 
     is_expected.to run.with_params(url, regtoken, 'active' => false).and_return(return_hash)
     expect(PuppetX::Gitlab::Runner).to have_received(:register)

--- a/spec/functions/register_to_file_spec.rb
+++ b/spec/functions/register_to_file_spec.rb
@@ -33,7 +33,7 @@ describe 'gitlab_ci_runner::register_to_file' do
 
   context "retrieves from Gitlab and writes auth token to file if it doesn't exist" do
     before do
-      allow(PuppetX::Gitlab::Runner).to receive(:register).with(url, { 'token' => regtoken }, nil).and_return(return_hash)
+      allow(PuppetX::Gitlab::Runner).to receive(:register).with(url, { 'token' => regtoken }, nil, nil).and_return(return_hash)
       allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:exist?).with(File.dirname(filename)).and_return(true)
       allow(File).to receive(:write).with(filename, return_hash['token'])

--- a/spec/functions/unregister_from_file_spec.rb
+++ b/spec/functions/unregister_from_file_spec.rb
@@ -17,7 +17,7 @@ describe 'gitlab_ci_runner::unregister_from_file' do
       allow(File).to receive(:exist?).with(filename).and_return(true)
       allow(File).to receive(:read).and_call_original
       allow(File).to receive(:read).with(filename).and_return('authtoken')
-      allow(PuppetX::Gitlab::Runner).to receive(:unregister).with(url, { token: 'authtoken' }, nil).and_return(nil)
+      allow(PuppetX::Gitlab::Runner).to receive(:unregister).with(url, { 'token' => 'authtoken' }, nil, nil).and_return(nil)
     end
 
     it { is_expected.to run.with_params(url, runner_name).and_return('Successfully unregistered gitlab runner testrunner') }

--- a/spec/functions/unregister_spec.rb
+++ b/spec/functions/unregister_spec.rb
@@ -14,7 +14,7 @@ describe 'gitlab_ci_runner::unregister' do
   it { is_expected.to run.with_params('https://gitlab.com', 'registration-token', project: 1234).and_raise_error(ArgumentError) }
 
   it "calls 'PuppetX::Gitlab::Runner.unregister'" do
-    allow(PuppetX::Gitlab::Runner).to receive(:unregister).with(url, token: authtoken).and_return(return_hash)
+    allow(PuppetX::Gitlab::Runner).to receive(:unregister).with(url, { 'token' => authtoken }, ca_file: nil).and_return(return_hash)
 
     is_expected.to run.with_params(url, authtoken).and_return(return_hash)
     expect(PuppetX::Gitlab::Runner).to have_received(:unregister)

--- a/spec/unit/puppet_x/gitlab/runner_spec.rb
+++ b/spec/unit/puppet_x/gitlab/runner_spec.rb
@@ -18,14 +18,14 @@ module PuppetX::Gitlab
           ).
           to_return(status: 204, body: '', headers: {})
 
-        expect(described_class.delete('https://example.org', {}, nil)).to eq({})
+        expect(described_class.delete('https://example.org', {}, nil, nil)).to eq({})
       end
 
       it 'raises an exception on non 200 http code' do
         stub_request(:delete, 'https://example.org').
           to_return(status: 403)
 
-        expect { described_class.delete('https://example.org', {}, nil) }.to raise_error(Net::HTTPError)
+        expect { described_class.delete('https://example.org', {}, nil, nil) }.to raise_error(Net::HTTPError)
       end
     end
 
@@ -43,14 +43,14 @@ module PuppetX::Gitlab
           ).
           to_return(status: 201, body: '{ "id": "12345", "token": "6337ff461c94fd3fa32ba3b1ff4125" }', headers: {})
 
-        expect(described_class.post('https://example.org', {}, nil)).to eq('id' => '12345', 'token' => '6337ff461c94fd3fa32ba3b1ff4125')
+        expect(described_class.post('https://example.org', {}, nil, nil)).to eq('id' => '12345', 'token' => '6337ff461c94fd3fa32ba3b1ff4125')
       end
 
       it 'raises an exception on non 200 http code' do
         stub_request(:delete, 'https://example.org').
           to_return(status: 501)
 
-        expect { described_class.delete('https://example.org', {}, nil) }.to raise_error(Net::HTTPError)
+        expect { described_class.delete('https://example.org', {}, nil, nil) }.to raise_error(Net::HTTPError)
       end
     end
 
@@ -58,7 +58,7 @@ module PuppetX::Gitlab
       context 'when doing a request' do
         before do
           stub_request(:post, 'example.org')
-          described_class.request('http://example.org/', Net::HTTP::Post, {}, nil)
+          described_class.request('http://example.org/', Net::HTTP::Post, {}, nil, nil)
         end
 
         it 'uses Accept: application/json' do
@@ -77,7 +77,7 @@ module PuppetX::Gitlab
       context 'when doing a HTTPS request' do
         before do
           stub_request(:post, 'https://example.org/')
-          described_class.request('https://example.org/', Net::HTTP::Post, {}, nil)
+          described_class.request('https://example.org/', Net::HTTP::Post, {}, nil, nil)
         end
 
         it 'uses SSL if url contains https://' do
@@ -92,10 +92,10 @@ module PuppetX::Gitlab
       before do
         PuppetX::Gitlab::APIClient.
           stub(:post).
-          with('https://gitlab.example.org/api/v4/runners', { token: 'registrationtoken' }, nil).
+          with('https://gitlab.example.org/api/v4/runners', { token: 'registrationtoken' }, nil, nil).
           and_return('id' => 1234, 'token' => '1234567890abcd')
       end
-      let(:response) { described_class.register('https://gitlab.example.org', { token: 'registrationtoken' }, nil) }
+      let(:response) { described_class.register('https://gitlab.example.org', { token: 'registrationtoken' }, nil, nil) }
 
       it 'returns a token' do
         expect(response['token']).to eq('1234567890abcd')
@@ -106,10 +106,10 @@ module PuppetX::Gitlab
       before do
         PuppetX::Gitlab::APIClient.
           stub(:delete).
-          with('https://gitlab.example.org/api/v4/runners', { token: '1234567890abcd' }, nil).
+          with('https://gitlab.example.org/api/v4/runners', { token: '1234567890abcd' }, nil, nil).
           and_return({})
       end
-      let(:response) { described_class.unregister('https://gitlab.example.org', { token: '1234567890abcd' }, nil) }
+      let(:response) { described_class.unregister('https://gitlab.example.org', { token: '1234567890abcd' }, nil, nil) }
 
       it 'returns an empty hash' do
         expect(response).to eq({})


### PR DESCRIPTION
#### Pull Request (PR) description
Added an optional parameter `ca_file` to `APIClient` that can specify a certificate authority file.
Added an optional parameter `ca_file` to `gitlab_ci_runner` and `gitlab_ci_runner::runner`

#### This Pull Request (PR) fixes the following issues
Fixes #124

