### PR TITLE
Fix puppet markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ For example:
 ```puppet
 class { 'gitlab_ci_runner':
   # [...]
-  runners: {
+  runners => {
     'my_runner' => {
-      'url'                => 'https://gitlab.com',
+      'url'                => 'https://gitlab.com/ci',
       'registration-token' => 'abcdef1234567890',
       'docker-image'       => 'ubuntu:focal',
     },
@@ -101,7 +101,7 @@ would need to be converted to:
 ```puppet
 class { 'gitlab_ci_runner':
   # [...]
-  runners: {
+  runners => {
     'my_runner' => {
       'url'                => 'https://gitlab.com',
       'registration-token' => 'abcdef1234567890',


### PR DESCRIPTION
While here, tune the url parameter to help people updating old setup to
spot that the url used to have a /ci component which must be removed
(per #126).
