### PR TITLE
Change to fix issue 144, check for presence of specifed ca_file (#1)

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -294,6 +294,7 @@ It can be used when the certificate of the gitlab server is signed using a CA
 and when upon registering a runner the following error is shown:
 `certificate verify failed (self signed certificate in certificate chain)`
 Using the CA file solves https://github.com/voxpupuli/puppet-gitlab_ci_runner/issues/124.
+The ca_file must exist, if it does not. Gitlab runner token generation will be skipped. Gitlab runner will not register until either the file exists or the ca_file parameter is not specified.
 
 Default value: ``undef``
 

--- a/lib/puppet/functions/gitlab_ci_runner/register_to_file.rb
+++ b/lib/puppet/functions/gitlab_ci_runner/register_to_file.rb
@@ -43,8 +43,8 @@ Puppet::Functions.create_function(:'gitlab_ci_runner::register_to_file') do
       begin
         # Confirm the specified ca file exists
         if !ca_file.nil? && !File.exist?(ca_file)
-          puts('Specified CA file doesn\'t exist for gitlab-ci-runner. Did you forget to create it?')
-          return 'Specified CA file doesn\'t exist, not creating authtoken'
+          Puppet.warning('Unable to register gitlab runner at this time as the specified `ca_file` does not exist (yet).  If puppet is managing this file, the next run should complete the registration process.')
+          return 'Specified CA file doesn\'t exist, not attempting to create authtoken'
         end
         authtoken = PuppetX::Gitlab::Runner.register(url, additional_options.merge('token' => regtoken), proxy, ca_file)['token']
 

--- a/lib/puppet/functions/gitlab_ci_runner/register_to_file.rb
+++ b/lib/puppet/functions/gitlab_ci_runner/register_to_file.rb
@@ -41,6 +41,11 @@ Puppet::Functions.create_function(:'gitlab_ci_runner::register_to_file') do
       return 'DUMMY-NOOP-TOKEN' if Puppet.settings[:noop]
 
       begin
+        # Confirm the specified ca file exists
+        if !ca_file.nil? && !File.exist?(ca_file)
+          puts('Specified CA file doesn\'t exist for gitlab-ci-runner. Did you forget to create it?')
+          return 'Specified CA file doesn\'t exist, not creating authtoken'
+        end
         authtoken = PuppetX::Gitlab::Runner.register(url, additional_options.merge('token' => regtoken), proxy, ca_file)['token']
 
         # If this function is used as a Deferred function the Gitlab Runner config dir

--- a/lib/puppet/functions/gitlab_ci_runner/unregister_from_file.rb
+++ b/lib/puppet/functions/gitlab_ci_runner/unregister_from_file.rb
@@ -34,6 +34,10 @@ Puppet::Functions.create_function(:'gitlab_ci_runner::unregister_from_file') do
       message
     else
       begin
+        if !ca_file.nil? && !File.exist?(ca_file)
+          Puppet.warning('Unable to unregister gitlab runner at this time as the specified `ca_file` does not exist. The runner config will be removed from this hosts config only; please remove from gitlab manually.')
+          return 'Specified CA file doesn\'t exist, not attempting to create authtoken'
+        end
         PuppetX::Gitlab::Runner.unregister(url, { 'token' => authtoken }, proxy, ca_file)
         message = "Successfully unregistered gitlab runner #{runner_name}"
         Puppet.debug message

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,6 +72,7 @@
 #   and when upon registering a runner the following error is shown:
 #   `certificate verify failed (self signed certificate in certificate chain)`
 #   Using the CA file solves https://github.com/voxpupuli/puppet-gitlab_ci_runner/issues/124.
+#   The ca_file must exist, if it does not. Gitlab runner token generation will be skipped. Gitlab runner will not register until either the file exists or the ca_file parameter is not specified.
 #
 class gitlab_ci_runner (
   String                                     $xz_package_name, # Defaults in module hieradata

--- a/spec/functions/register_to_file_spec.rb
+++ b/spec/functions/register_to_file_spec.rb
@@ -44,12 +44,20 @@ describe 'gitlab_ci_runner::register_to_file' do
 
     it { is_expected.to run.with_params(url, regtoken, runner_name).and_return(return_hash['token']) }
 
-    context 'with ca_file option' do
+    context 'with existing file ca_file option' do
+      before do
+        allow(PuppetX::Gitlab::Runner).to receive(:register).with(url, { 'token' => regtoken }, nil, '/tmp').and_return(return_hash)
+      end
+
+      it { is_expected.to run.with_params(url, regtoken, runner_name, {}, nil, '/tmp').and_return(return_hash['token']) }
+    end
+
+    context 'with non existent ca_file option' do
       before do
         allow(PuppetX::Gitlab::Runner).to receive(:register).with(url, { 'token' => regtoken }, nil, '/path/to/ca_file').and_return(return_hash)
       end
 
-      it { is_expected.to run.with_params(url, regtoken, runner_name, {}, nil, '/path/to/ca_file').and_return(return_hash['token']) }
+      it { is_expected.to run.with_params(url, regtoken, runner_name, {}, nil, '/path/to/ca_file').and_return('Specified CA file doesn\'t exist, not creating authtoken') }
     end
   end
 

--- a/spec/functions/register_to_file_spec.rb
+++ b/spec/functions/register_to_file_spec.rb
@@ -57,7 +57,7 @@ describe 'gitlab_ci_runner::register_to_file' do
         allow(PuppetX::Gitlab::Runner).to receive(:register).with(url, { 'token' => regtoken }, nil, '/path/to/ca_file').and_return(return_hash)
       end
 
-      it { is_expected.to run.with_params(url, regtoken, runner_name, {}, nil, '/path/to/ca_file').and_return('Specified CA file doesn\'t exist, not creating authtoken') }
+      it { is_expected.to run.with_params(url, regtoken, runner_name, {}, nil, '/path/to/ca_file').and_return('Specified CA file doesn\'t exist, not attempting to create authtoken') }
     end
   end
 

--- a/spec/functions/unregister_from_file_spec.rb
+++ b/spec/functions/unregister_from_file_spec.rb
@@ -24,12 +24,20 @@ describe 'gitlab_ci_runner::unregister_from_file' do
 
     it { is_expected.to run.with_params(url, runner_name).and_return('Successfully unregistered gitlab runner testrunner') }
 
-    context 'with ca_file option' do
+    context 'with existing file ca_file option' do
+      before do
+        allow(PuppetX::Gitlab::Runner).to receive(:unregister).with(url, { 'token' => 'authtoken' }, nil, '/tmp').and_return(nil)
+      end
+
+      it { is_expected.to run.with_params(url, runner_name, nil, '/tmp').and_return('Successfully unregistered gitlab runner testrunner') }
+    end
+
+    context 'with non existent ca_file option' do
       before do
         allow(PuppetX::Gitlab::Runner).to receive(:unregister).with(url, { 'token' => 'authtoken' }, nil, '/path/to/ca_file').and_return(nil)
       end
 
-      it { is_expected.to run.with_params(url, runner_name, nil, '/path/to/ca_file').and_return('Successfully unregistered gitlab runner testrunner') }
+      it { is_expected.to run.with_params(url, runner_name, nil, '/path/to/ca_file').and_return('Specified CA file doesn\'t exist, not attempting to create authtoken') }
     end
   end
 


### PR DESCRIPTION

#### Pull Request (PR) description

Fixes issue 144 by adding a check to confirm if the ca_file set in the parameters actually exists on the machine.

This problem causes Puppet runs to completely fail when using a Gitlab server with an internally signed CA. Making it impossible to install the ca file with Puppet when the gitlab_ci_runner module is in use.

Added rspec test to check this new condition. 

Tests passing in github actions (with the exception of the Ubuntu 18.04 on Puppet 6 which was already failing.).

Docker build . test passing (to the same standard as the existing master branch). Output provided below.

I'm not sure if we should output a message to the user. See register_to_file.rb line 46. Or it should be let to fail silently. Thoughts?

#### This Pull Request (PR) fixes the following issues

Fixes #144 

```
------                                                                                                                                                       
 > [8/9] RUN bundle exec rake release_checks:                                                                                                                
#12 1.020 ruby -c lib/puppet/functions/gitlab_ci_runner/unregister_from_file.rb                                                                              
#12 1.049 Syntax OK                                                                                                                                          
#12 1.050 ruby -c lib/puppet/functions/gitlab_ci_runner/register.rb                                                                                          
#12 1.078 Syntax OK                                                                                                                                          
#12 1.079 ruby -c lib/puppet/functions/gitlab_ci_runner/unregister.rb
#12 1.105 Syntax OK
#12 1.106 ruby -c lib/puppet/functions/gitlab_ci_runner/to_toml.rb
#12 1.131 Syntax OK
#12 1.132 ruby -c lib/puppet/functions/gitlab_ci_runner/register_to_file.rb
#12 1.159 Syntax OK
#12 1.160 ruby -c lib/puppet_x/gitlab/dumper.rb
#12 1.186 Syntax OK
#12 1.187 ruby -c lib/puppet_x/gitlab/runner.rb
#12 1.212 Syntax OK
#12 1.213 ---> syntax:manifests
#12 1.361 ---> syntax:templates
#12 1.388 ---> syntax:hiera:yaml
#12 1.406 I, [2022-03-07T06:11:38.471937 #8]  INFO -- : Creating symlink from spec/fixtures/modules/gitlab_ci_runner to /opt/puppet
#12 1.411 Cloning into 'spec/fixtures/modules/stdlib'...
#12 1.413 Cloning into 'spec/fixtures/modules/ruby_task_helper'...
#12 1.416 Cloning into 'spec/fixtures/modules/apt'...
#12 1.419 Cloning into 'spec/fixtures/modules/concat'...
#12 1.422 Cloning into 'spec/fixtures/modules/docker'...
#12 1.425 Cloning into 'spec/fixtures/modules/translate'...
#12 1.428 Cloning into 'spec/fixtures/modules/yumrepo_core'...
#12 3.003 4 processes for 10 specs, ~ 2 specs per process
#12 4.128 ..
#12 4.141 An error occurred while loading ./spec/tasks/unregister_runner_spec.rb. - Did you mean?
#12 4.141                     rspec ./spec/tasks/register_runner_spec.rb
#12 4.141 
#12 4.141 Failure/Error: require_relative '../../tasks/unregister_runner'
#12 4.141 
#12 4.141 LoadError:
#12 4.141   cannot load such file -- /opt/ruby_task_helper/files/task_helper
#12 4.141 # ./tasks/unregister_runner.rb:5:in `require_relative'
#12 4.141 # ./tasks/unregister_runner.rb:5:in `<top (required)>'
#12 4.141 # ./spec/tasks/unregister_runner_spec.rb:4:in `require_relative'
#12 4.141 # ./spec/tasks/unregister_runner_spec.rb:4:in `<top (required)>'
#12 4.141 
#12 4.141 
#12 4.141 Finished in 0.00002 seconds (files took 0.97614 seconds to load)
#12 4.141 0 examples, 0 failures, 1 error occurred outside of examples
#12 4.141 
#12 4.146 .......Specified CA file doesn't exist for gitlab-ci-runner. Did you forget to create it?
#12 4.212 .............................
#12 4.458 
#12 4.458 Finished in 0.38674 seconds (files took 0.91178 seconds to load)
#12 4.458 38 examples, 0 failures
#12 4.458 
#12 7.580 
#12 7.580 An error occurred while loading ./spec/tasks/register_runner_spec.rb. - Did you mean?
#12 7.580                     rspec ./spec/tasks/unregister_runner_spec.rb
#12 7.580 
#12 7.580 Failure/Error: require_relative '../../tasks/register_runner'
#12 7.580 
#12 7.580 LoadError:
#12 7.580   cannot load such file -- /opt/ruby_task_helper/files/task_helper
#12 7.580 # ./tasks/register_runner.rb:5:in `require_relative'
#12 7.580 # ./tasks/register_runner.rb:5:in `<top (required)>'
#12 7.580 # ./spec/tasks/register_runner_spec.rb:4:in `require_relative'
#12 7.580 # ./spec/tasks/register_runner_spec.rb:4:in `<top (required)>'
#12 7.580 
#12 7.580 
#12 7.580 Finished in 0.00002 seconds (files took 4.42 seconds to load)
#12 7.580 0 examples, 0 failures, 1 error occurred outside of examples
#12 7.580 
#12 7.840 .................................................................................................................................................................................................................................................................................................................................................................................................
#12 21.23 
#12 21.23 Coverage Report:
#12 21.23 
#12 21.23 Total resources:   21
#12 21.23 Touched resources: 16
#12 21.23 Resource coverage: 76.19%
#12 21.23 
#12 21.23 Untouched resources:
#12 21.23   Concat::Fragment[/etc/gitlab-runner/config.toml - runner_with_ensure_present]
#12 21.23   Concat::Fragment[/etc/gitlab-runner/config.toml - test_runner]
#12 21.23   File[/etc/gitlab-runner/auth-token-runner_with_ensure_absent]
#12 21.23   Package[xz-utils]
#12 21.23   Package[xz]
#12 21.23 
#12 21.23 
#12 21.23 Finished in 13.73 seconds (files took 4.34 seconds to load)
#12 21.23 385 examples, 0 failures
#12 21.23 
#12 21.25 Tests Failed
#12 21.26 
#12 21.26 2 errors, 423 examples, 0 failures
#12 21.26 
#12 21.26 Took 18 seconds
```