### PR TITLE
Ubuntu 18 Puppet 6: Install lsb-release during CI

### DIFF
--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -50,3 +50,10 @@ file_line { '/etc/hosts-squid':
   path => '/etc/hosts',
   line => "${facts['squid_ip']} squid",
 }
+
+# Needed for os.distro.codebase fact on ubuntu 16/18 on puppet 6
+if $facts['os']['name'] == 'Ubuntu' and versioncmp($facts['puppetversion'], '7.0.0') < 0 {
+  package{'lsb-release':
+    ensure => present,
+  }
+}


### PR DESCRIPTION
This is our usual bugfix to workaround the missing dependency of facter.