### PR TITLE
register_to_file: Support Sensitive `regtoken`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -504,7 +504,7 @@ gitlab_ci_runner::runner { 'testrunner':
 }
 ```
 
-#### `gitlab_ci_runner::register_to_file(String[1] $url, String[1] $regtoken, String[1] $runner_name, Optional[Hash] $additional_options, Optional[Optional[String[1]]] $proxy, Optional[Optional[String[1]]] $ca_file)`
+#### `gitlab_ci_runner::register_to_file(String[1] $url, Variant[String[1], Sensitive[String[1]]] $regtoken, String[1] $runner_name, Optional[Hash] $additional_options, Optional[Optional[String[1]]] $proxy, Optional[Optional[String[1]]] $ca_file)`
 
 A function that registers a Gitlab runner on a Gitlab instance, if it doesn't already exist,
 _and_ saves the retrieved authentication token to a file. This is helpful for Deferred functions.
@@ -533,7 +533,7 @@ The url to your Gitlab instance. Please only provide the host part (e.g https://
 
 ##### `regtoken`
 
-Data type: `String[1]`
+Data type: `Variant[String[1], Sensitive[String[1]]]`
 
 Registration token.
 

--- a/lib/puppet/functions/gitlab_ci_runner/register_to_file.rb
+++ b/lib/puppet/functions/gitlab_ci_runner/register_to_file.rb
@@ -25,7 +25,7 @@ Puppet::Functions.create_function(:'gitlab_ci_runner::register_to_file') do
   dispatch :register_to_file do
     # We use only core data types because others aren't synced to the agent.
     param 'String[1]', :url
-    param 'String[1]', :regtoken
+    param 'Variant[String[1], Sensitive[String]]', :regtoken
     param 'String[1]', :runner_name
     optional_param 'Hash', :additional_options
     optional_param 'Optional[String[1]]', :proxy
@@ -46,6 +46,11 @@ Puppet::Functions.create_function(:'gitlab_ci_runner::register_to_file') do
           Puppet.warning('Unable to register gitlab runner at this time as the specified `ca_file` does not exist (yet).  If puppet is managing this file, the next run should complete the registration process.')
           return 'Specified CA file doesn\'t exist, not attempting to create authtoken'
         end
+
+        # If this is a Sensitive value it will be unwrapped, otherwise the String
+        # will be returned unmodified.
+        regtoken = call_function('unwrap', regtoken)
+
         authtoken = PuppetX::Gitlab::Runner.register(url, additional_options.merge('token' => regtoken), proxy, ca_file)['token']
 
         # If this function is used as a Deferred function the Gitlab Runner config dir

--- a/lib/puppet/functions/gitlab_ci_runner/register_to_file.rb
+++ b/lib/puppet/functions/gitlab_ci_runner/register_to_file.rb
@@ -25,7 +25,7 @@ Puppet::Functions.create_function(:'gitlab_ci_runner::register_to_file') do
   dispatch :register_to_file do
     # We use only core data types because others aren't synced to the agent.
     param 'String[1]', :url
-    param 'Variant[String[1], Sensitive[String]]', :regtoken
+    param 'Variant[String[1], Sensitive[String[1]]]', :regtoken
     param 'String[1]', :runner_name
     optional_param 'Hash', :additional_options
     optional_param 'Optional[String[1]]', :proxy

--- a/spec/functions/register_to_file_spec.rb
+++ b/spec/functions/register_to_file_spec.rb
@@ -59,6 +59,14 @@ describe 'gitlab_ci_runner::register_to_file' do
 
       it { is_expected.to run.with_params(url, regtoken, runner_name, {}, nil, '/path/to/ca_file').and_return('Specified CA file doesn\'t exist, not attempting to create authtoken') }
     end
+
+    context 'with sensitive token value' do
+      before do
+        allow(PuppetX::Gitlab::Runner).to receive(:register).with(url, { 'token' => regtoken }, nil, '/tmp').and_return(return_hash)
+      end
+
+      it { is_expected.to run.with_params(url, sensitive(regtoken), runner_name, {}, nil, '/tmp').and_return(return_hash['token']) }
+    end
   end
 
   context 'noop does not register runner and returns dummy token' do


### PR DESCRIPTION
#### Pull Request (PR) description

When retrieving a runner registration token from a lookup plugin such as `vault_lookup` the token will be marked as Sensitive. This change allows for an object of `Sensitive[String]` type to be passed in for `regtoken` and ensures it is properly unwrapped before use.