### PR TITLE
Apt keyring

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -16,7 +16,7 @@ class gitlab_ci_runner::repo (
         location => "${repo_base_url}/runner/${package_name}/${facts['os']['distro']['id'].downcase}/",
         repos    => 'main',
         key      => {
-          'id'     => 'F6403F6544A38863DAA0B6E03F01618A51312F3F',
+          'name'   => 'gitlab_ci_runner.gpg',
           'source' => $repo_keysource,
           'server' => $repo_keyserver,
         },


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->

#### Pull Request (PR) description

in repo::debian, change the apt key definition in the apt source: remove "id" and set "name" in place. 

This will make apt use the keyrings (in /etc/apt/keyrings) instead of apt-key's trusted store, since apt-key is now deprecated.