### PR TITLE
Drop Debian 10 and Ubuntu 18.04 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Changing these after registration has no affect.
 The Gitlab CI runner installation is at the moment only tested on:
 * CentOS 7/8
 * Debian 10/11
-* Ubuntu 18.04/20.04/22.04
+* Ubuntu 20.04/22.04
 
 For the current list of tested and support operating systems, please checkout the metadata.json file.
 

--- a/README.md
+++ b/README.md
@@ -121,11 +121,6 @@ Changing these after registration has no affect.
 
 ## Limitations
 
-The Gitlab CI runner installation is at the moment only tested on:
-* CentOS 7/8
-* Debian 10/11
-* Ubuntu 20.04/22.04
-
 For the current list of tested and support operating systems, please checkout the metadata.json file.
 
 It is currently not possible to alter registration specific configuration settings after a runner is registered.

--- a/metadata.json
+++ b/metadata.json
@@ -73,14 +73,12 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10",
         "11"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04",
         "20.04",
         "22.04"
       ]

--- a/spec/classes/gitlab_ci_runner_spec.rb
+++ b/spec/classes/gitlab_ci_runner_spec.rb
@@ -330,30 +330,27 @@ describe 'gitlab_ci_runner', type: :class do
         end
       end
 
-      # puppetlabs-docker doesn't support CentOS 6 anymore.
-      unless facts[:os]['name'] == 'CentOS' && facts[:os]['release']['major'] == '6'
-        context 'with manage_docker => true' do
-          let(:params) do
-            {
-              manage_docker: true
-            }
-          end
+      context 'with manage_docker => true' do
+        let(:params) do
+          {
+            manage_docker: true
+          }
+        end
 
-          it { is_expected.to compile }
+        it { is_expected.to compile }
 
-          it { is_expected.to contain_class('docker') }
+        it { is_expected.to contain_class('docker') }
 
-          it do
-            is_expected.to contain_class('docker::images').
-              with(
-                images: {
-                  'ubuntu_focal' => {
-                    'image' => 'ubuntu',
-                    'image_tag' => 'focal'
-                  }
+        it do
+          is_expected.to contain_class('docker::images').
+            with(
+              images: {
+                'ubuntu_focal' => {
+                  'image' => 'ubuntu',
+                  'image_tag' => 'focal'
                 }
-              )
-          end
+              }
+            )
         end
       end
 

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -9,15 +9,6 @@ package { 'curl':
   ensure => present,
 }
 
-# https://gitlab.com/gitlab-org/omnibus-gitlab/issues/2229
-# There is no /usr/share/zoneinfo in latest Docker image for ubuntu 16.04
-# Gitlab installer fail without this file
-if $facts['os']['release']['major'] in ['16.04', '18.04'] {
-  package { 'tzdata':
-    ensure => present,
-  }
-}
-
 # Setup Puppet Bolt
 $bolt_config = @("BOLTPROJECT"/L)
 modulepath: "/etc/puppetlabs/code/modules:/etc/puppetlabs/code/environments/production/modules"


### PR DESCRIPTION
#### Pull Request (PR) description

Remove Debian 10 and Ubuntu 18.04 support.

Also:
*  Some redundant cases for CentOS 6 and Ubuntu 16.04
*  Updates README to remove explicit naming of supported OSes. Rely on metadata.json.


