### PR TITLE
Upgrade Github CI and drop RHEL 7-based operating systems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 ---
-# Managed by modulesync - DO NOT EDIT
+# (NOT) Managed by modulesync???
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
 name: CI
@@ -21,11 +21,11 @@ jobs:
     env:
       BUNDLE_WITHOUT: development:system_tests:release
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.3'
           bundler-cache: true
       - name: Run static validations
         run: bundle exec rake validate lint check
@@ -48,7 +48,7 @@ jobs:
       PUPPET_VERSION: "~> ${{ matrix.puppet }}.0"
     name: Puppet ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }})
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -61,7 +61,7 @@ jobs:
 
   acceptance:
     needs: setup_matrix
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       BUNDLE_WITHOUT: development:test:release
     strategy:
@@ -70,11 +70,11 @@ jobs:
         include: ${{fromJson(needs.setup_matrix.outputs.github_action_test_matrix)}}
     name: ${{ matrix.puppet.name }} - ${{ matrix.setfile.name }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.3'
           bundler-cache: true
       - name: Start gitlab
         run: ./scripts/start-gitlab.sh

--- a/metadata.json
+++ b/metadata.json
@@ -29,7 +29,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7",
         "8",
         "9"
       ]
@@ -37,7 +36,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7",
         "8",
         "9"
       ]
@@ -59,15 +57,8 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "7",
         "8",
         "9"
-      ]
-    },
-    {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "7"
       ]
     },
     {


### PR DESCRIPTION
Upgrading the testing setup as part of a major rewrite to support the new runner registration flow