### PR TITLE
Avoid use of lsb facts

### DIFF
--- a/spec/classes/gitlab_ci_runner_spec.rb
+++ b/spec/classes/gitlab_ci_runner_spec.rb
@@ -375,7 +375,7 @@ describe 'gitlab_ci_runner', type: :class do
             is_expected.to contain_apt__source('apt_gitlabci').
               with(
                 comment: 'GitlabCI Runner Repo',
-                location: "https://packages.gitlab.com/runner/gitlab-runner/#{facts[:lsbdistid].downcase}/",
+                location: "https://packages.gitlab.com/runner/gitlab-runner/#{facts[:os]['name'].downcase}/",
                 repos: 'main',
                 key: {
                   'name' => 'gitlab_ci_runner.asc',


### PR DESCRIPTION
#### Pull Request (PR) description

The spec tests were still relying on LSB facts.
Stop doing that.

Certainly for Ubuntu and Debian `$facts['lsbdistid'] == $facts['os']['name']`.
