### PR TITLE
Enable gpgcheck for YUM  RPM based Distributions

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -101,6 +101,8 @@ The following parameters are available in the `gitlab_ci_runner` class:
 * [`http_proxy`](#-gitlab_ci_runner--http_proxy)
 * [`ca_file`](#-gitlab_ci_runner--ca_file)
 * [`repo_keysource`](#-gitlab_ci_runner--repo_keysource)
+* [`package_keysource`](#-gitlab_ci_runner--package_keysource)
+* [`package_gpgcheck`](#-gitlab_ci_runner--package_gpgcheck)
 
 ##### <a name="-gitlab_ci_runner--runners"></a>`runners`
 
@@ -369,6 +371,22 @@ Data type: `Stdlib::HTTPSUrl`
 URL to the gpg file used to sign the apt packages
 
 Default value: `"${repo_base_url}/gpg.key"`
+
+##### <a name="-gitlab_ci_runner--package_keysource"></a>`package_keysource`
+
+Data type: `Optional[Stdlib::HTTPSUrl]`
+
+
+
+Default value: `undef`
+
+##### <a name="-gitlab_ci_runner--package_gpgcheck"></a>`package_gpgcheck`
+
+Data type: `Boolean`
+
+
+
+Default value: `true`
 
 ## Defined types
 

--- a/data/family/RedHat.yaml
+++ b/data/family/RedHat.yaml
@@ -1,2 +1,3 @@
 ---
 gitlab_ci_runner::xz_package_name: 'xz'
+gitlab_ci_runner::package_keysource: 'https://packages.gitlab.com/runner/gitlab-runner/gpgkey/runner-gitlab-runner-49F16C5CC3A0F81F.pub.gpg'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,6 +122,8 @@ class gitlab_ci_runner (
   Optional[Stdlib::HTTPUrl]                  $http_proxy        = undef,
   Optional[Stdlib::Unixpath]                 $ca_file           = undef,
   Stdlib::HTTPSUrl                           $repo_keysource    = "${repo_base_url}/gpg.key",
+  Optional[Stdlib::HTTPSUrl]                 $package_keysource = undef,
+  Boolean                                    $package_gpgcheck  = true,
 ) {
   if $manage_docker {
     # workaround for cirunner issue #1617

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -3,10 +3,12 @@
 # @api private
 #
 class gitlab_ci_runner::repo (
-  $repo_base_url  = $gitlab_ci_runner::repo_base_url,
-  $repo_keyserver = $gitlab_ci_runner::repo_keyserver,
-  $repo_keysource = $gitlab_ci_runner::repo_keysource,
-  $package_name   = $gitlab_ci_runner::package_name,
+  $repo_base_url     = $gitlab_ci_runner::repo_base_url,
+  $repo_keyserver    = $gitlab_ci_runner::repo_keyserver,
+  $repo_keysource    = $gitlab_ci_runner::repo_keysource,
+  $package_keysource = $gitlab_ci_runner::package_keysource,
+  $package_gpgcheck  = $gitlab_ci_runner::package_gpgcheck,
+  $package_name      = $gitlab_ci_runner::package_name,
 ) {
   assert_private()
   case $facts['os']['family'] {
@@ -42,13 +44,14 @@ class gitlab_ci_runner::repo (
         $source_base_url = "${repo_base_url}/runner/${package_name}/el/\$releasever/SRPMS"
       }
 
+      $_gpgkeys = [$repo_keysource,$package_keysource].delete_undef_values.join(' ')
       yumrepo { "runner_${package_name}":
         ensure        => 'present',
         baseurl       => $base_url,
         descr         => "runner_${package_name}",
         enabled       => '1',
-        gpgcheck      => '0',
-        gpgkey        => $repo_keysource,
+        gpgcheck      => String(Integer($package_gpgcheck)),
+        gpgkey        => $_gpgkeys,
         repo_gpgcheck => '1',
         sslcacert     => '/etc/pki/tls/certs/ca-bundle.crt',
         sslverify     => '1',
@@ -59,8 +62,8 @@ class gitlab_ci_runner::repo (
         baseurl       => $source_base_url,
         descr         => "runner_${package_name}-source",
         enabled       => '1',
-        gpgcheck      => '0',
-        gpgkey        => $repo_keysource,
+        gpgcheck      => String(Integer($package_gpgcheck)),
+        gpgkey        => $_gpgkeys,
         repo_gpgcheck => '1',
         sslcacert     => '/etc/pki/tls/certs/ca-bundle.crt',
         sslverify     => '1',

--- a/spec/classes/gitlab_ci_runner_spec.rb
+++ b/spec/classes/gitlab_ci_runner_spec.rb
@@ -406,8 +406,8 @@ describe 'gitlab_ci_runner', type: :class do
                 baseurl: "https://packages.gitlab.com/runner/gitlab-runner/el/#{os_release_version}/$basearch",
                 descr: 'runner_gitlab-runner',
                 enabled: '1',
-                gpgcheck: '0',
-                gpgkey: 'https://packages.gitlab.com/gpg.key',
+                gpgcheck: '1',
+                gpgkey: 'https://packages.gitlab.com/gpg.key https://packages.gitlab.com/runner/gitlab-runner/gpgkey/runner-gitlab-runner-49F16C5CC3A0F81F.pub.gpg',
                 repo_gpgcheck: '1',
                 sslcacert: '/etc/pki/tls/certs/ca-bundle.crt',
                 sslverify: '1'
@@ -421,12 +421,26 @@ describe 'gitlab_ci_runner', type: :class do
                 baseurl: "https://packages.gitlab.com/runner/gitlab-runner/el/#{os_release_version}/SRPMS",
                 descr: 'runner_gitlab-runner-source',
                 enabled: '1',
-                gpgcheck: '0',
-                gpgkey: 'https://packages.gitlab.com/gpg.key',
+                gpgcheck: '1',
+                gpgkey: 'https://packages.gitlab.com/gpg.key https://packages.gitlab.com/runner/gitlab-runner/gpgkey/runner-gitlab-runner-49F16C5CC3A0F81F.pub.gpg',
                 repo_gpgcheck: '1',
                 sslcacert: '/etc/pki/tls/certs/ca-bundle.crt',
                 sslverify: '1'
               )
+          end
+
+          context 'when package_gpgcheck is false' do
+            let(:params) do
+              super().merge(package_gpgcheck: false)
+            end
+
+            it do
+              is_expected.to contain_yumrepo('runner_gitlab-runner').with_gpgcheck('0')
+            end
+
+            it do
+              is_expected.to contain_yumrepo('runner_gitlab-runner-source').with_gpgcheck('0')
+            end
           end
         end
       end


### PR DESCRIPTION
#### Pull Request (PR) description

Currently the yum repositories for gitlab runner installations are preset with a hardcoded `gpgcheck => 0`.

Introduce new parameters:

* `pacakage_gpgcheck` defaulting to true that sets `gpgcheck => 1` for yum based distributions.
* `package_keysource` defaulting to current location of the gpg key for gitlab package.

By default gpgchecking will now be enabled for RPM/YUM based distributions which was not the case before.

See:

* Package signature https://docs.gitlab.com/runner/install/linux-repository.html#rpm-based-distributions
* Repository signature  https://packages.gitlab.com/app/gitlab/gitlab-ce/gpg
